### PR TITLE
Autoremove trailing spaces when saving JavaScript buffers.

### DIFF
--- a/vimrc
+++ b/vimrc
@@ -70,7 +70,7 @@ autocmd InsertEnter * match ExtraWhitespace /\s\+\%#\@<!$/
 autocmd BufRead,InsertLeave * match ExtraWhitespace /\s\+$/
 
 " Autoremove trailing spaces when saving the buffer
-autocmd FileType ruby,c,cpp,java,php,html autocmd BufWritePre <buffer> :%s/\s\+$//e
+autocmd FileType ruby,c,cpp,java,javascript,php,html autocmd BufWritePre <buffer> :%s/\s\+$//e
 
 " Highlight too-long lines
 autocmd BufRead,InsertEnter,InsertLeave * 2match LineLengthError /\%126v.*/


### PR DESCRIPTION
Can we add JavaScript files to the list of types that get automatic whitespace removal?
