### PR TITLE
prevent delay on O

### DIFF
--- a/vimrc
+++ b/vimrc
@@ -93,6 +93,9 @@ set statusline+=%10(L(%l/%L)%)\           " line
 set statusline+=%2(C(%v/125)%)\           " column
 set statusline+=%P                        " percentage of file
 
+" Prevent O delay
+set timeout timeoutlen=3000 ttimeoutlen=100
+
 " ========= Plugin Options ========
 
 let g:AckAllFiles = 0


### PR DESCRIPTION
This prevents the annoying delay that happens when you hit O immediately after ESC in normal mode.
