### PR TITLE
Pasting over a selection does not alter the register

### DIFF
--- a/vimrc
+++ b/vimrc
@@ -179,6 +179,9 @@ nnoremap <silent> Y y$
 
 map <silent> <LocalLeader>ws :highlight clear ExtraWhitespace<CR>
 
+" Pasting over a selection does not replace the clipboard
+xnoremap <expr> p 'pgv"'.v:register.'y'
+
 " ========= Insert Shortcuts ========
 
 imap <C-L> <SPACE>=><SPACE>


### PR DESCRIPTION
Have you ever copied a line with the intention of pasting over something else?
Afterward, you try to paste the same line somewhere else...but the register content was replaced by the line that you pasted over!

This fixes that problem. Using `p` over a selection does not alter the register used to paste. You can freely use `p` to paste over selections multiple times without having to re-yank the original text :)
