### PR TITLE
Map jk to switch to command mode

### DIFF
--- a/vimrc
+++ b/vimrc
@@ -186,6 +186,10 @@ xnoremap <expr> p 'pgv"'.v:register.'y'
 
 imap <C-L> <SPACE>=><SPACE>
 
+" ========= Map jk to switch to command mode ========
+
+imap jk <Esc>
+
 " ========= Functions ========
 
 command! SudoW w !sudo tee %


### PR DESCRIPTION
This change provides an alternative to `Esc` and `Ctrl-[` for switching to command mode by using the `jk` keystroke combo.

`jk` is much easier to type since they're adjacent keys on the home row. The combination is also rarely used while typing so it's not really an annoyance for unintentionally switching to command mode.

More Details:
http://vim.wikia.com/wiki/Avoid_the_escape_key
