### PR TITLE
netrw shouldn't hide parent directory

### DIFF
--- a/vim/after/plugin/netrw_list_hide.vim
+++ b/vim/after/plugin/netrw_list_hide.vim
@@ -1,0 +1,1 @@
+let g:netrw_list_hide = '^.*\.pyc$,^.*\.o$,^.*\.class$,^.*\.lo$'


### PR DESCRIPTION
Currently the only way to navigate up when browsing is by hitting `-`, this commit prevents the `..` entry from being hidden from directory listings.

This change isn't made to vimrc because `g:netrw_list_hide` is mangled by [vinegar](https://github.com/braintreeps/vim_dotfiles/tree/master/vim/bundle/vim-vinegar) and must be changed after the plugins have finished running.
