### PR TITLE
Correct node_modules and bower_components ignores for CtrlP

### DIFF
--- a/vimrc
+++ b/vimrc
@@ -29,7 +29,7 @@ set dir=/tmp//
 set scrolloff=5
 set ignorecase
 set smartcase
-set wildignore+=*.pyc,*.o,*.class,*.lo,.git,vendor/*,node_modules/**,bower_components/**
+set wildignore+=*.pyc,*.o,*.class,*.lo,.git,vendor/*,*/node_modules/*,*/bower_components/*
 set tags+=gems.tags
 
 if version >= 703


### PR DESCRIPTION
In the switch from CommandT to CtrlP the `wildignore` entries for `node_modules` and `bower_components` stopped working. This restores the behavior