### PR TITLE
Add vimux command to describe current spec

### DIFF
--- a/vimrc
+++ b/vimrc
@@ -162,6 +162,7 @@ map <silent> <LocalLeader>vx :wa<CR> :VimuxClosePanes<CR>
 map <silent> <LocalLeader>vp :VimuxPromptCommand<CR>
 vmap <silent> <LocalLeader>vs "vy :call VimuxRunCommand(@v)<CR>
 nmap <silent> <LocalLeader>vs vip<LocalLeader>vs<CR>
+map <silent> <LocalLeader>ds :call VimuxRunCommand('clear; grep -E "^ *describe[ \(]\|^ *context[ \(]\|^ *it[ \(]" ' . bufname("%"))<CR>
 
 map <silent> <LocalLeader>rt :!ctags -R --exclude=".git\|.svn\|log\|tmp\|db\|pkg" --extra=+f --langmap=Lisp:+.clj<CR>
 


### PR DESCRIPTION
Worked on this with @tlrobrn. We used @ideal-knee's grep regex magic.

Running `<leader>ds` (describe spec) should output this for the spec you are currently on:

![screen shot 2015-06-05 at 2 52 44 pm](https://cloud.githubusercontent.com/assets/2916945/8014049/00113390-0b93-11e5-9897-e26bf5203500.png)
![screen shot 2015-06-05 at 2 51 59 pm](https://cloud.githubusercontent.com/assets/2916945/8014050/0012014e-0b93-11e5-9101-451f4c03935d.png)

Works for RSpec and Mocha files.
