### PR TITLE
Add line to prevent folding in markdown files

### DIFF
--- a/vimrc
+++ b/vimrc
@@ -138,6 +138,8 @@ let g:CommandTCancelMap     = ['<ESC>', '<C-c>']
 let g:CommandTSelectNextMap = ['<C-n>', '<C-j>', '<ESC>OB']
 let g:CommandTSelectPrevMap = ['<C-p>', '<C-k>', '<ESC>OA']
 
+let g:vim_markdown_folding_disabled=1
+
 " ========= Shortcuts ========
 
 " NERDTree


### PR DESCRIPTION
## Problem 

By default, vim-markdown does a lot of folding on markdown files. 

## Solution 

Per [this section of the vim-markdown repo](https://github.com/plasticboy/vim-markdown#disable-folding), that can be easily disabled.

For markdown heavy repos, this is a must. 