### PR TITLE
Pin bufexplorer to working version on braintreeps repo

### DIFF
--- a/vimrc.bundles
+++ b/vimrc.bundles
@@ -8,7 +8,7 @@ else
   call plug#begin('~/.vim/plugged')
 endif
 
-Plug 'jlanzarotta/bufexplorer'
+Plug 'braintreeps/bufexplorer'
 Plug 'mileszs/ack.vim'
 Plug 'vim-scripts/Align'
 Plug 'bkad/CamelCaseMotion'


### PR DESCRIPTION
Now bufexplorer points here: https://github.com/braintreeps/bufexplorer

Which is the working version of buffer explorer in Drew's dotfiles.