### PR TITLE
Move vendor ignores from wildignore to command_t ignore

### DIFF
--- a/vimrc
+++ b/vimrc
@@ -34,7 +34,7 @@ set dir=/tmp//
 set scrolloff=5
 set ignorecase
 set smartcase
-set wildignore+=*.pyc,*.o,*.class,*.lo,.git,vendor/*,node_modules/**,bower_components/**
+set wildignore+=*.pyc,*.o,*.class,*.lo,.git
 set tags+=gems.tags
 
 if version >= 703
@@ -137,6 +137,7 @@ let g:CommandTMatchWindowAtTop = 1
 let g:CommandTCancelMap     = ['<ESC>', '<C-c>']
 let g:CommandTSelectNextMap = ['<C-n>', '<C-j>', '<ESC>OB']
 let g:CommandTSelectPrevMap = ['<C-p>', '<C-k>', '<ESC>OA']
+let g:CommandTWildIgnore=&wildignore . ",vendor/*,node_modules/**,bower_components/**"
 
 let g:vim_markdown_folding_disabled=1
 


### PR DESCRIPTION
I often want to open files in `node_modules` or `bower_components` (to hack on or inspect); since we use `wildignore` to remove those files from CommandT,  we miss out on path completion and other niceties. Using [`CommandTWildIgnore`](https://github.com/wincent/command-t/blob/master/doc/command-t.txt#L779) allows the best of both worlds.