### PR TITLE
Update trim to stay on same line after substitution

### DIFF
--- a/vimrc
+++ b/vimrc
@@ -223,6 +223,7 @@ nnoremap <silent> <Leader>gw :GitGrepWord<CR>
 
 function! Trim()
   %s/\s*$//
+  ''
 endfunction
 command! -nargs=0 Trim :call Trim()
 nnoremap <silent> <Leader>cw :Trim<CR>


### PR DESCRIPTION
Previously running <leader>cw would move you to the bottom of the file after running. This change should keep your cursor where it was previously positioned.