### PR TITLE
Update Clojure stuff

### DIFF
--- a/vimrc
+++ b/vimrc
@@ -111,10 +111,6 @@ let html_use_css=1
 let html_number_lines=0
 let html_no_pre=1
 
-let vimclojure#WantNailgun = 0
-let vimclojure#HighlightBuiltins = 1
-let vimclojure#ParenRainbow = 1
-
 let g:gist_clip_command = 'pbcopy'
 let g:gist_detect_filetype = 1
 
@@ -139,6 +135,11 @@ let g:CommandTSelectNextMap = ['<C-n>', '<C-j>', '<ESC>OB']
 let g:CommandTSelectPrevMap = ['<C-p>', '<C-k>', '<ESC>OA']
 
 let g:vim_markdown_folding_disabled=1
+
+autocmd VimEnter *       RainbowParenthesesToggle
+autocmd Syntax   clojure RainbowParenthesesLoadRound
+autocmd Syntax   clojure RainbowParenthesesLoadSquare
+autocmd Syntax   clojure RainbowParenthesesLoadBraces
 
 " ========= Shortcuts ========
 

--- a/vimrc.bundles
+++ b/vimrc.bundles
@@ -25,8 +25,8 @@ Plug 'jergason/scala.vim'
 Plug 'tomtom/tcomment_vim'
 Plug 'davidzchen/vim-bazel'
 Plug 'tpope/vim-classpath'
-Plug 'vim-scripts/VimClojure'
 Plug 'guns/vim-clojure-static'
+Plug 'guns/vim-clojure-highlight'
 Plug 'kchmck/vim-coffee-script'
 Plug 'benmills/vim-commadown'
 Plug 'tpope/vim-cucumber'
@@ -51,6 +51,7 @@ Plug 'drewolson/vimux-elixir-test'
 Plug 'pitluga/vimux-nose-test'
 Plug 'pgr0ss/vimux-ruby-test'
 Plug 'tpope/vim-vinegar'
+Plug 'kien/rainbow_parentheses.vim'
 
 if filereadable(expand("~/.vimrc.bundles.local"))
   source ~/.vimrc.bundles.local


### PR DESCRIPTION
Remove deprecated VimClojure, add vim-clojure-highlight and rainbow_parentheses.vim.

This is an attempt to get the common Vim config to a decent place to edit Clojure.  It is targeted at folks that are ~new to Clojure/don't have strong enough opinions on how they want to have their editor configured (yet.)  Some tools that I'm on the fence about adding:

  * [paredit](https://github.com/vim-scripts/paredit.vim)/[vim-sexp](https://github.com/tpope/vim-sexp-mappings-for-regular-people) (for easier/more structured Lisp editing)
  * [salve.vim](https://github.com/tpope/vim-salve) (integrate repl/test/build into Vim)
  * [vim-cljfmt](https://github.com/venantius/vim-cljfmt) (formatting)

I also plan to write up a quick start for using these plugins.

Any feedback would be appreciated.