### PR TITLE
Stricter regexen for NERDTreeIgnore

### DIFF
--- a/vimrc
+++ b/vimrc
@@ -125,7 +125,7 @@ let g:no_html_toolbar = 'yes'
 
 let coffee_no_trailing_space_error = 1
 
-let NERDTreeIgnore=['\.pyc', '\.o', '\.class', '\.lo']
+let NERDTreeIgnore=['\.pyc$', '\.o$', '\.class$', '\.lo$']
 let NERDTreeHijackNetrw = 0
 
 let g:netrw_banner = 0


### PR DESCRIPTION
Add an EOL match for ignore rules so files like ‘Checkout.class.php’
don’t get ignored while ‘JavaBeanFactory.class’ is ignored as intended.