### PR TITLE
Change PmenuSel foreground to NONE to fix iTerm visibility

### DIFF
--- a/vim/colors/vibrantink.vim
+++ b/vim/colors/vibrantink.vim
@@ -65,4 +65,5 @@ else
     highlight String ctermfg=82 
     highlight Search ctermbg=White 
     highlight CursorLine cterm=NONE ctermbg=235
+    highlight PmenuSel ctermfg=NONE
 endif


### PR DESCRIPTION
An upgrade of command-t caused it to use `PmenuSel` for the selected file foreground and background. The current combo of `ctermfg=0` and `ctermbg=242` makes the text invisible in iTerm (or at least my terminal). Changing it so `ctermfg=NONE` mimics the previous behavior when command-t used `Visual` for the highlighting.