### PR TITLE
Switch to vim-puppet instead of vim-puppet-syntax.

### DIFF
--- a/vimrc
+++ b/vimrc
@@ -148,6 +148,8 @@ if exists(':RainbowParenthesesToggle')
   autocmd Syntax   clojure RainbowParenthesesLoadBraces
 endif
 
+let g:puppet_align_hashes = 0
+
 " ========= Shortcuts ========
 
 " NERDTree

--- a/vimrc.bundles
+++ b/vimrc.bundles
@@ -19,7 +19,7 @@ Plug 'vim-scripts/mako.vim'
 Plug 'godlygeek/tabular' | Plug 'plasticboy/vim-markdown'
 Plug 'vim-scripts/matchit.zip'
 Plug 'scrooloose/nerdtree'
-Plug 'braintreeps/puppet-syntax-vim'
+Plug 'voxpupuli/vim-puppet', { 'commit': 'e88c19bf10763b30f86b7417677f59a9c9487fa2' }
 Plug 'derekwyatt/vim-scala'
 Plug 'jergason/scala.vim'
 Plug 'tomtom/tcomment_vim'


### PR DESCRIPTION
As best I can tell, vim-puppet is a fork of vim-puppet-syntax that is
more actively maintained. Switching means we don't need to have our own
fork of vim-puppet-syntax anymore (it added the unless keyword in too),
and gives us the ability to turn automatic alignment in hashes on and
off, instead of forcing it on (see the one change to vimrc).