### PR TITLE
Update vimrc to set foldmethod to indent

### DIFF
--- a/vimrc
+++ b/vimrc
@@ -83,6 +83,10 @@ endif
 autocmd InsertEnter * match ExtraWhitespace /\s\+\%#\@<!$/
 autocmd BufRead,InsertLeave * match ExtraWhitespace /\s\+$/
 
+" Use folding but start unfolded
+set foldmethod=indent
+autocmd BufWinEnter * silent! :%foldopen!
+
 " Autoremove trailing spaces when saving the buffer
 autocmd FileType c,cpp,elixir,eruby,html,java,javascript,php,ruby autocmd BufWritePre <buffer> :%s/\s\+$//e
 


### PR DESCRIPTION
To avoid changing the behavior when opening files, this includes an `autocmd` to force all folds fully open.