### PR TITLE
Add side-search plugin

### DIFF
--- a/vimrc
+++ b/vimrc
@@ -116,6 +116,19 @@ set statusline+=%P                        " percentage of file
 let g:AckAllFiles = 0
 let g:AckCmd = 'ack --type-add ruby=.feature --ignore-dir=tmp 2> /dev/null'
 
+" Side Search {{{
+let g:side_search_prg = 'ack-grep --word-regexp'
+       \. " --heading -C 2 --group"
+let g:side_search_splitter = 'vnew'
+let g:side_search_split_pct = 0.4
+
+" SideSearch current word and return to original window
+nnoremap <Leader>ss :SideSearch <C-r><C-w><CR> | wincmd p
+
+" SS shortcut and return to original window
+ command! -complete=file -nargs=+ SS execute 'SideSearch <args>'
+" }}}
+
 let html_use_css=1
 let html_number_lines=0
 let html_no_pre=1

--- a/vimrc.bundles
+++ b/vimrc.bundles
@@ -54,6 +54,7 @@ Plug 'tpope/vim-vinegar'
 Plug 'kien/rainbow_parentheses.vim'
 Plug 'ekalinin/Dockerfile.vim'
 Plug 'google/vim-jsonnet'
+Plug 'ddrscott/vim-side-search'
 
 if filereadable(expand("~/.vimrc.bundles.local"))
   source ~/.vimrc.bundles.local


### PR DESCRIPTION
This plugin allows for the following functionality:

1. <leader\>ss will open up every instance of the word under the cursor in a side panel
2. :SS <word to search\> will open up any instance of the specified word
3. Scrolling between instances of that word within files and in-between files is super easy (with n for next and N for  #previous)
4. Seeing the context around the instances of that word is very helpful

Please view gif below:

![side_search_plugin](https://cloud.githubusercontent.com/assets/6074497/21732397/eafb4d5a-d41e-11e6-82d5-c6225be8d5d0.gif)



