### PR TITLE
Use Ctrl-P instead of Command-T

### DIFF
--- a/vimrc
+++ b/vimrc
@@ -146,12 +146,10 @@ let g:netrw_banner = 0
 
 let g:VimuxUseNearestPane = 1
 
-let g:CommandTMaxHeight = 15
-let g:CommandTMatchWindowAtTop = 1
-let g:CommandTCancelMap     = ['<ESC>', '<C-c>']
-let g:CommandTSelectNextMap = ['<C-n>', '<C-j>', '<ESC>OB']
-let g:CommandTSelectPrevMap = ['<C-p>', '<C-k>', '<ESC>OA']
-let g:CommandTWildIgnore=&wildignore . ",vendor/*,node_modules/**,bower_components/**"
+let g:ctrlp_custom_ignore = {
+  \ 'dir': '(vendor|node_modules|bower_components)'
+  \ }
+let g:ctrlp_match_window = 'top,order:ttb,min:1,max:15'
 
 let g:vim_markdown_folding_disabled=1
 
@@ -172,9 +170,10 @@ map <silent> <LocalLeader>nr :NERDTree<CR>
 map <silent> <LocalLeader>nf :NERDTreeFind<CR>
 
 " CommandT
-map <silent> <leader>ff :CommandT<CR>
-map <silent> <leader>fb :CommandTBuffer<CR>
-map <silent> <leader>fr :CommandTFlush<CR>
+map <silent> <leader>ff :CtrlP<CR>
+map <silent> <leader>fb :CtrlPBuffer<CR>
+map <silent> <leader>fm :CtrlPMRU<CR>
+map <silent> <leader>fa :CtrlPMixed<CR>
 
 " Ack
 map <LocalLeader>aw :Ack '<C-R><C-W>'

--- a/vimrc.bundles
+++ b/vimrc.bundles
@@ -55,6 +55,7 @@ Plug 'kien/rainbow_parentheses.vim'
 Plug 'ekalinin/Dockerfile.vim'
 Plug 'google/vim-jsonnet'
 Plug 'ddrscott/vim-side-search'
+Plug 'ctrlpvim/ctrlp.vim'
 
 if filereadable(expand("~/.vimrc.bundles.local"))
   source ~/.vimrc.bundles.local


### PR DESCRIPTION
Ctrl-P is like Command-T, but with some more powerful features. In addition to fuzzy finding it has a most-recently-used file list and a buffer explorer. You can search with regexes. You can mark multiple files to open in their own buffers, and also open them in new splits or tabs.

Here it is in action:

![ctrl-p](https://cloud.githubusercontent.com/assets/1365093/23570017/fa7a8eb4-0027-11e7-8326-22cb2bbc1efd.gif)

To check it out, clone my fork onto a machine, `git checkout use_ctrl_p`, and `rake`.

See the plugin for more info: https://github.com/ctrlpvim/ctrlp.vim