### PR TITLE
Set backupcopy for top-level file mounting in Docker

### DIFF
--- a/vimrc
+++ b/vimrc
@@ -36,6 +36,7 @@ set ignorecase
 set smartcase
 set wildignore+=*.pyc,*.o,*.class,*.lo,.git,vendor/*,node_modules/**,bower_components/**,*/build_gradle/*,*/build_intellij/*,*/build/*,*/cassandra_data/*
 set tags+=gems.tags
+set backupcopy=yes " Setting backup copy preserves file inodes, which are needed for Docker file mounting
 
 if version >= 703
   set undodir=~/.vim/undodir


### PR DESCRIPTION
Vim's default saving behavior writes a new file, which breaks the bind mount
for any top level files (this is unlike directory-mounting behavior, since
directories are aware of file inodes). Setting backupcopy allows for
changes to top level files on the host to propagate to the container.