### PR TITLE
Adds async linting and completion choices

### DIFF
--- a/vimrc.bundles
+++ b/vimrc.bundles
@@ -60,6 +60,10 @@ Plug 'vim-scripts/Align'
 Plug 'vim-scripts/mako.vim'
 Plug 'vim-scripts/matchit.zip'
 Plug 'vim-scripts/VimClojure'
+if v:version >= 800 || has('nvim')
+  Plug 'w0rp/ale'
+  Plug 'maralla/completor.vim'
+endif
 if filereadable(expand("~/.vimrc.bundles.local"))
   source ~/.vimrc.bundles.local
 endif


### PR DESCRIPTION
Both of these plugins support Vim8 and Neovim and will not block the UI while the are doing their work. I have enabled them only if Vim8 or Neovim is detected.

## Linting

This PR makes use of [w0rp/ale](https://github.com/w0rp/ale) for non-blocking linting of the current file. It has out-of-the-box support for many linting systems.

For instance, in Python it will automatically use `flake8` in the current virtualenv to lint the current buffer and add mark the lines that need attention.

![](https://raw.githubusercontent.com/w0rp/ale/master/img/example.gif)

## Completion

This PR makes use of [completor.vim](https://github.com/maralla/completor.vim) for as-you-type completion suggestions.

For instance, in a Python project if you have `jedi` installed in the current virtualenv it will automatically supply completion suggestions for library method calls, classes, etc.

![](https://camo.githubusercontent.com/0dcc3b75a89c1366910d913fa5668a5b004fedb7/687474703a2f2f692e696d6775722e636f6d2f6635456f6941362e676966)