### PR TITLE
Add unimpaired.vim

### DIFF
--- a/vimrc.bundles
+++ b/vimrc.bundles
@@ -55,6 +55,7 @@ Plug 'kien/rainbow_parentheses.vim'
 Plug 'ekalinin/Dockerfile.vim'
 Plug 'google/vim-jsonnet'
 Plug 'ddrscott/vim-side-search'
+Plug 'tpope/vim-unimpaired'
 
 if filereadable(expand("~/.vimrc.bundles.local"))
   source ~/.vimrc.bundles.local


### PR DESCRIPTION
[tpope/vim-unimpaired](https://github.com/tpope/vim-unimpaired) Adds a number of handy mappings.

Some highlights
  - `]q`, `[q` for navigating the quickfix list
  - `]<Space>`, `[<Space>` for inserting lines without leaving normal mode
  - `]f`, `[f` for switching to the next/previous file

As far as I've seen, there aren't any conflicts