### PR TITLE
Add configuration for async linting

### DIFF
--- a/vimrc
+++ b/vimrc
@@ -108,6 +108,9 @@ set statusline+=%P                        " percentage of file
 let g:AckAllFiles = 0
 let g:AckCmd = 'ack --type-add ruby=.feature --ignore-dir=tmp 2> /dev/null'
 
+let g:ale_lint_on_text_changed = 'normal' " Only lint while in normal mode
+let g:ale_lint_on_insert_leave = 1        " Automatically lint when leaving insert mode
+
 let html_use_css=1
 let html_number_lines=0
 let html_no_pre=1


### PR DESCRIPTION
Based on conversations in [braintreeps/vim_dotfiles#56](https://github.com/braintreeps/vim_dotfiles/pull/56), we're thinking the addition of these two options makes for a nice compromise as opposed to completely getting rid of [w0rp/ale](https://github.com/w0rp/ale).

What this change effectively means is "only lint in normal mode and always lint when exiting insert mode".  The net effect is you don't get the weird linting-while-typing behavior.