### PR TITLE
Disable completor.vim automatic suggestions

### DIFF
--- a/vimrc
+++ b/vimrc
@@ -151,6 +151,8 @@ let g:go_highlight_trailing_whitespace_error = 0
 
 let g:terraform_fmt_on_save = 1
 
+let g:completor_auto_trigger = 0
+
 " ========= Shortcuts ========
 
 " NERDTree

--- a/vimrc.bundles
+++ b/vimrc.bundles
@@ -63,6 +63,7 @@ Plug 'vim-scripts/matchit.zip'
 Plug 'vim-scripts/VimClojure'
 if v:version >= 800 || has('nvim')
   Plug 'w0rp/ale'
+  Plug 'maralla/completor.vim'
 endif
 if filereadable(expand("~/.vimrc.bundles.local"))
   source ~/.vimrc.bundles.local

--- a/vimrc.bundles
+++ b/vimrc.bundles
@@ -63,7 +63,6 @@ Plug 'vim-scripts/matchit.zip'
 Plug 'vim-scripts/VimClojure'
 if v:version >= 800 || has('nvim')
   Plug 'w0rp/ale'
-  Plug 'maralla/completor.vim'
 endif
 if filereadable(expand("~/.vimrc.bundles.local"))
   source ~/.vimrc.bundles.local


### PR DESCRIPTION
#Until a more non-invasive configuration can be decided on, we are disabling automatic suggestion presentation in this plugin.

See #57 #56 #51 