### PR TITLE
Keep the signcolumn always open and make it the background color

### DIFF
--- a/vim/colors/vibrantink.vim
+++ b/vim/colors/vibrantink.vim
@@ -45,6 +45,7 @@ if has("gui_running")
     highlight String guifg=#66FF00
     highlight Search guibg=White
     highlight CursorLine guibg=#323300
+    highlight clear SignColumn
 else
     set t_Co=256
     highlight Normal ctermfg=White ctermbg=NONE
@@ -65,4 +66,5 @@ else
     highlight String ctermfg=82 
     highlight Search ctermbg=White 
     highlight CursorLine cterm=NONE ctermbg=235
+    highlight clear SignColumn
 endif

--- a/vimrc
+++ b/vimrc
@@ -37,6 +37,7 @@ set smartcase
 set wildignore+=*.pyc,*.o,*.class,*.lo,.git,vendor/*,node_modules/**,bower_components/**,*/build_gradle/*,*/build_intellij/*,*/build/*,*/cassandra_data/*
 set tags+=gems.tags
 set backupcopy=yes " Setting backup copy preserves file inodes, which are needed for Docker file mounting
+set signcolumn=yes
 
 if version >= 703
   set undodir=~/.vim/undodir


### PR DESCRIPTION
This prevents it from opening and closing when w0rp/ale linting finds errors.

Here's a gif showing the old behavior:

![signcolumn](https://cloud.githubusercontent.com/assets/12998/26705515/87984002-46eb-11e7-8f3e-d7d8319f05a1.gif)

And the new behavior:

![signcolumn_after](https://cloud.githubusercontent.com/assets/12998/26705664/61beb04a-46ec-11e7-9cc0-f58f9895bb98.gif)
