### PR TITLE
Specifically ignore folders for fzf

### DIFF
--- a/vimrc
+++ b/vimrc
@@ -141,7 +141,7 @@ let g:netrw_banner = 0
 
 let g:VimuxUseNearestPane = 1
 
-let $FZF_DEFAULT_COMMAND = 'find * -type f 2>/dev/null | grep -v -E "deps|_build|node_modules|vendor|build_intellij"'
+let $FZF_DEFAULT_COMMAND = 'find * -type f 2>/dev/null | grep -v -E "deps/|_build/|node_modules/|vendor/|build_intellij/"' 
 let $FZF_DEFAULT_OPTS = '--reverse'
 let g:fzf_tags_command = 'ctags -R --exclude=".git\|.svn\|log\|tmp\|db\|pkg" --extra=+f --langmap=Lisp:+.clj'
 


### PR DESCRIPTION
Previously, we would ignore anything with the characters `_build` which
would includer things like `view_builders`. This commit explicitly sets
the ignored sections to be folders, not just file names.