### PR TITLE
Do not run terraform fmt on .tfvars files

### DIFF
--- a/vimrc
+++ b/vimrc
@@ -92,6 +92,9 @@ autocmd ColorScheme * highlight LineLengthError ctermbg=black guibg=black
 highlight ExtraWhitespace ctermbg=red guibg=red
 autocmd ColorScheme * highlight ExtraWhitespace ctermbg=red guibg=red
 
+" Run terraform fmt on terraform files
+autocmd BufWritePre *.tf call terraform#fmt()
+
 " Status
 set laststatus=2
 set statusline=
@@ -149,8 +152,6 @@ let g:vim_markdown_folding_disabled = 1
 
 let g:go_fmt_command = "goimports"
 let g:go_highlight_trailing_whitespace_error = 0
-
-let g:terraform_fmt_on_save = 1
 
 let g:completor_auto_trigger = 0
 


### PR DESCRIPTION
As it stands right now, the hashicorp terraform plugin will mangle our tfvars files, it alphabetizes them and adds newlines after each variable definition.  That's all fine and great, but it makes logical visual separation like very difficult.  For example, you can't do:

```
zookeeper_instance_count = 1
kafka_instance_count = 1

cassandra_instance_count = 1
cassandra_baz_count = 2
```