### PR TITLE
FZF: Add an additional split binding to mimic ctrlp

### DIFF
--- a/vimrc
+++ b/vimrc
@@ -180,6 +180,11 @@ let g:puppet_align_hashes = 0
 let $FZF_DEFAULT_COMMAND = 'find * -type f 2>/dev/null | grep -v -E "deps/|_build/|node_modules/|vendor/|build_intellij/"' 
 let $FZF_DEFAULT_OPTS = '--reverse'
 let g:fzf_tags_command = 'ctags -R --exclude=".git\|.svn\|log\|tmp\|db\|pkg" --extra=+f --langmap=Lisp:+.clj'
+let g:fzf_action = {
+  \ 'ctrl-t': 'tab split',
+  \ 'ctrl-x': 'split',
+  \ 'ctrl-s': 'split',
+  \ 'ctrl-v': 'vsplit' }
 
 let g:vim_markdown_folding_disabled = 1
 


### PR DESCRIPTION
This adds an additional binding for splitting from the FZF finder ala ctrl-p (`<Ctrl-x>` will still work). I'm also a fan of this because `s for split` is an easier mnemonic device, but that's rather subjective ;)

FZF doesn't [merge `g:fzf_action` with its defaults](https://github.com/junegunn/fzf.vim/blob/master/autoload/fzf/vim.vim#L330), so we need to specify the entire mapping here instead of just specifying one of them :\ 
