### PR TITLE
Don't use tags for autocomplete

### DIFF
--- a/vimrc
+++ b/vimrc
@@ -39,6 +39,7 @@ set tags+=gems.tags
 set mouse=
 set backupcopy=yes " Setting backup copy preserves file inodes, which are needed for Docker file mounting
 set signcolumn=yes
+set complete-=t " Don't use tags for autocomplete
 
 if version >= 703
   set undodir=~/.vim/undodir


### PR DESCRIPTION
Something changed recently that causes autocomplete to be really slow
initially as it says its "Scanning tags...". It's hard to say why this
suddenly started happening because it looks like it's default behavior
for vim to look at tags for autocomplete. This change fixes it by
explicitly removing tags from the autocomplete suggestions.