### PR TITLE
Stop clearing trailing whitespace when saving

### DIFF
--- a/vimrc
+++ b/vimrc
@@ -86,9 +86,6 @@ endif
 autocmd InsertEnter * match ExtraWhitespace /\s\+\%#\@<!$/
 autocmd BufRead,InsertLeave * match ExtraWhitespace /\s\+$/
 
-" Autoremove trailing spaces when saving the buffer
-autocmd FileType c,cpp,elixir,eruby,html,java,javascript,php,ruby autocmd BufWritePre <buffer> :%s/\s\+$//e
-
 " Highlight too-long lines
 autocmd BufRead,InsertEnter,InsertLeave * 2match LineLengthError /\%126v.*/
 highlight LineLengthError ctermbg=black guibg=black


### PR DESCRIPTION
This behavior I find more frustrating than useful:

- We already highlight trailing whitespace
- New users are not aware this change is being made when the save
- With this config in place it is difficult to keep whitespace when you
  want it, e.g. trying to make a minimal diff that does not introduce
  extraneous changes.