### PR TITLE
Do not switch colorschemes for diffs

### DIFF
--- a/vimrc
+++ b/vimrc
@@ -51,10 +51,6 @@ set undolevels=1000 "maximum number of changes that can be undone
 " Color
 colorscheme vibrantink
 
-au FileType diff colorscheme desert
-au FileType git colorscheme desert
-au BufWinLeave * colorscheme vibrantink
-
 augroup markdown
   au!
   au BufNewFile,BufRead *.md,*.markdown setlocal filetype=ghmarkdown


### PR DESCRIPTION
This colorscheme switching breaks highlighting of trailing whitespace.

This change does make diffs in vim look worse, but it mostly fixes
whitespace highlighting.

There is still an issue where highlithing is removed on the new window
when a file is split. It still remains in the original window, however.