### PR TITLE
Update vim-ruby and use "variable" assignment indentation

### DIFF
--- a/vimrc
+++ b/vimrc
@@ -144,7 +144,7 @@ let g:gist_clip_command = 'pbcopy'
 let g:gist_detect_filetype = 1
 
 let g:rubycomplete_buffer_loading = 1
-
+let g:ruby_indent_assignment_style = 'variable'
 
 let g:no_html_toolbar = 'yes'
 

--- a/vimrc.bundles
+++ b/vimrc.bundles
@@ -64,7 +64,7 @@ Plug 'tpope/vim-surround'
 Plug 'tpope/vim-unimpaired'
 Plug 'tpope/vim-vinegar'
 Plug 'uarun/vim-protobuf'
-Plug 'vim-ruby/vim-ruby', { 'commit': 'c9f55233d752b8ba69c5f3b28e94304e60f3c45b' }
+Plug 'vim-ruby/vim-ruby', { 'commit': '074200ffa39b19baf9d9750d399d53d97f21ee07' }
 Plug 'vim-scripts/Align'
 Plug 'vim-scripts/VimClojure'
 Plug 'vim-scripts/mako.vim'


### PR DESCRIPTION
Rather than the default "hanging" indentation style:

``` ruby
something = if condition
              # ...
            else
              # ...
            end
```

Newer versions of vim-ruby allow the awkwardly named "variable" indentation, which is more inline with our style:

``` ruby
something = if condition
  # ...
else
  # ...
end
```