### PR TITLE
Give long lines a red background highlight

### DIFF
--- a/vimrc
+++ b/vimrc
@@ -88,8 +88,8 @@ autocmd BufRead,InsertLeave * match ExtraWhitespace /\s\+$/
 
 " Highlight too-long lines
 autocmd BufRead,InsertEnter,InsertLeave * 2match LineLengthError /\%126v.*/
-highlight LineLengthError ctermbg=black guibg=black
-autocmd ColorScheme * highlight LineLengthError ctermbg=black guibg=black
+highlight LineLengthError ctermbg=red guibg=red
+autocmd ColorScheme * highlight LineLengthError ctermbg=red guibg=red
 
 " Set up highlight group & retain through colorscheme changes
 highlight ExtraWhitespace ctermbg=red guibg=red


### PR DESCRIPTION
For those of us who use a dark colorscheme for their terminal, the
current 'black' background highlight for long lines is invisible. I
didn't actually realise we had *any* highlighting of long lines until I
investigated adding it and discovered this configuration.

This gives long lines (> 125 chars) a 'red' background, just as we do
for trailing whitespace. It appears this was the initial configuration
when [line length highlighting was added][1] back in 2010. However,
shortly after, the background was changed [from red to black][2], as it
is today. It's not clear why that change was made and whether terminals
with black backgrounds were considered. If anybody has any context on
this – and a long memory – please chime in!

Before:

![screen shot 2017-09-25 at 2 02 50 pm](https://user-images.githubusercontent.com/597448/30830872-61eba3fc-a1fa-11e7-9d0d-5e50b20afb78.png)

After:

![screen shot 2017-09-25 at 1 59 16 pm](https://user-images.githubusercontent.com/597448/30830898-7757fc54-a1fa-11e7-8cba-1ee7b872f4db.png)

[1]: https://github.com/braintreeps/vim_dotfiles/commit/aef4be7eed594b56f349815063d2e5bed3329a35
[2]: https://github.com/braintreeps/vim_dotfiles/commit/64e1df32705ad5c87608bdef0b677b2af5e9ce01