### PR TITLE
Revert "Give long lines a red background highlight"

### DIFF
--- a/vimrc
+++ b/vimrc
@@ -84,8 +84,8 @@ autocmd BufRead,InsertLeave * match ExtraWhitespace /\s\+$/
 
 " Highlight too-long lines
 autocmd BufRead,InsertEnter,InsertLeave * 2match LineLengthError /\%126v.*/
-highlight LineLengthError ctermbg=red guibg=red
-autocmd ColorScheme * highlight LineLengthError ctermbg=red guibg=red
+highlight LineLengthError ctermbg=black guibg=black
+autocmd ColorScheme * highlight LineLengthError ctermbg=black guibg=black
 
 " Set up highlight group & retain through colorscheme changes
 highlight ExtraWhitespace ctermbg=red guibg=red


### PR DESCRIPTION
Reverts braintreeps/vim_dotfiles#78

Unfortunately, this can cause a bit of eye-bleeding for files/projects with a large amount of very long lines.