### PR TITLE
Rename File via :Rename

### DIFF
--- a/vimrc
+++ b/vimrc
@@ -78,6 +78,21 @@ if version >= 700
     autocmd FileType tex setlocal spell spelllang=en_us
 endif
 
+" File IO Helpers
+" --------------
+
+" rename current file from Gary Bernhardt
+function! RenameFile()
+  let old_name = expand('%')
+  let new_name = input('New file name: ', expand('%'))
+  if new_name != '' && new_name != old_name
+    exec ':saveas ' . new_name
+    exec ':silent !rm ' . old_name
+    redraw!
+  endif
+endfunction
+command! Rename call RenameFile()
+
 " Highlight trailing whitespace
 autocmd InsertEnter * match ExtraWhitespace /\s\+\%#\@<!$/
 autocmd BufRead,InsertLeave * match ExtraWhitespace /\s\+$/


### PR DESCRIPTION
This commit allows you to rename a file via `<leader>rn` (*r*e*n*ame file), it will rename the file and redraw the current buffer.  I've found this useful since I rarely use nerdtree.  My only thought is the alias might be confusing since we use the letter `r` to generally mean `run`.  Open to alternatives if the team doesn't like this mapping.

looks like:

![screen shot 2017-10-12 at 11 14 36 am](https://user-images.githubusercontent.com/5561166/31504173-b5a4698c-af3f-11e7-923c-b4241215dd90.png)

