### PR TITLE
Turn off both types of mouse mode.

### DIFF
--- a/vimrc
+++ b/vimrc
@@ -37,6 +37,7 @@ set smartcase
 set wildignore+=*.pyc,*.o,*.class,*.lo,.git,vendor/*,node_modules/**,bower_components/**,*/build_gradle/*,*/build_intellij/*,*/build/*,*/cassandra_data/*
 set tags+=gems.tags
 set mouse=
+set ttymouse=
 set backupcopy=yes " Setting backup copy preserves file inodes, which are needed for Docker file mounting
 set signcolumn=yes
 set complete-=t " Don't use tags for autocomplete


### PR DESCRIPTION
It seems with a vim upgrade or something else, mouse mode is sometimes start by default, `set ttymouse=` will turn it off in the cases where `set mouse=` is ignored.