### PR TITLE
Use pry rather than ruby-debug for LocalLeader rd

### DIFF
--- a/vim/ruby_mappings.vim
+++ b/vim/ruby_mappings.vim
@@ -53,5 +53,5 @@ function! _IsInferiorSlimeRunning()
   end
 endfunction
 
-map <LocalLeader>rd Orequire 'ruby-debug';debugger<ESC>
+map <LocalLeader>rd Orequire "pry"; binding.pry<ESC>
 setlocal isk+=?


### PR DESCRIPTION
Since I don't think ruby-debug is very useful anymore, how about remapping this to pry?