### PR TITLE
Remove completor from core vim config

### DIFF
--- a/vimrc
+++ b/vimrc
@@ -186,8 +186,6 @@ let g:vim_markdown_folding_disabled = 1
 let g:go_fmt_command = "goimports"
 let g:go_highlight_trailing_whitespace_error = 0
 
-let g:completor_auto_trigger = 0
-
 " ========= Shortcuts ========
 
 " NERDTree

--- a/vimrc.bundles
+++ b/vimrc.bundles
@@ -74,7 +74,6 @@ Plug 'voxpupuli/vim-puppet', { 'commit': 'e88c19bf10763b30f86b7417677f59a9c9487f
 
 if v:version >= 800 || has('nvim')
   Plug 'w0rp/ale'
-  Plug 'maralla/completor.vim'
 endif
 if filereadable(expand("~/.vimrc.bundles.local"))
   source ~/.vimrc.bundles.local


### PR DESCRIPTION
We've recently had some issues where completor is triggering for developers who do not use the plugin. I am similarly in the camp where I do not use or want to use completor. 

Because of this current problem and similar issues with configuration, I'd like to propose we move towards a pattern where enhancements like this are pushed into `~/.vimrc.bundles.local` and  `~/.vimrc_local`. That way teams who regularly use these can maintain their own dotfile customizations (which currently works in all development environments) without needing to worry about affecting anyone else.

If there's a strong case for moving or keeping something in the core I think it's totally acceptable to do so but i'd prefer to keep the core vimrc as trim and generally useful as possible. This gives us the freedom to experiment with divergent tooling without affecting other developers. If something reaches that critical mass we can then cannonize it in the official vimrc and make it part of the onboarding / pairing process.