### PR TITLE
Add a command to show the URL for the current file in Git

### DIFF
--- a/vimrc
+++ b/vimrc
@@ -273,10 +273,12 @@ command! -nargs=0 GitGrepWord :call GitGrepWord()
 nnoremap <silent> <Leader>gw :GitGrepWord<CR>
 
 function! GitHubURL() range
-  let repo = systemlist("git config --get remote.origin.url | sed 's/\.git$//' | sed 's_^git@\\(.*\\):_https://\\1/_'")[0]
-  let branch = systemlist("git rev-parse HEAD")[0]
+  let branch = systemlist("git name-rev --name-only HEAD")[0]
+  let remote = systemlist("git config branch." . branch . ".remote")[0]
+  let repo = systemlist("git config --get remote." . remote . ".url | sed 's/\.git$//' | sed 's_^git@\\(.*\\):_https://\\1/_' | sed 's_^git://_https://_'")[0]
+  let revision = systemlist("git rev-parse HEAD")[0]
   let path = systemlist("git ls-files --full-name " . @%)[0]
-  let url = repo . "/blob/" . branch . "/" . path . "#L" . a:firstline . "-L" . a:lastline
+  let url = repo . "/blob/" . revision . "/" . path . "#L" . a:firstline . "-L" . a:lastline
   echomsg url
 endfunction
 command! -range GitHubURL <line1>,<line2>call GitHubURL()

--- a/vimrc
+++ b/vimrc
@@ -272,14 +272,14 @@ endfunction
 command! -nargs=0 GitGrepWord :call GitGrepWord()
 nnoremap <silent> <Leader>gw :GitGrepWord<CR>
 
-function! GitWebURL() range
+function! GitHubURL() range
   let repo = systemlist("git config --get remote.origin.url | sed 's/\.git$//' | sed 's_^git@\\(.*\\):_https://\\1/_'")[0]
   let branch = systemlist("git rev-parse HEAD")[0]
   let path = systemlist("git ls-files --full-name " . @%)[0]
   let url = repo . "/blob/" . branch . "/" . path . "#L" . a:firstline . "-L" . a:lastline
   echomsg url
 endfunction
-command! -range GitWebURL <line1>,<line2>call GitWebURL()
+command! -range GitHubURL <line1>,<line2>call GitHubURL()
 
 function! Trim()
   %s/\s*$//

--- a/vimrc
+++ b/vimrc
@@ -272,6 +272,15 @@ endfunction
 command! -nargs=0 GitGrepWord :call GitGrepWord()
 nnoremap <silent> <Leader>gw :GitGrepWord<CR>
 
+function! GitWebURL() range
+  let repo = systemlist("git config --get remote.origin.url | sed 's/\.git$//' | sed 's_^git@\\(.*\\):_https://\\1/_'")[0]
+  let branch = systemlist("git rev-parse HEAD")[0]
+  let path = systemlist("git ls-files --full-name " . @%)[0]
+  let url = repo . "/blob/" . branch . "/" . path . "#L" . a:firstline . "-L" . a:lastline
+  echomsg url
+endfunction
+command! -range GitWebURL <line1>,<line2>call GitWebURL()
+
 function! Trim()
   %s/\s*$//
   ''


### PR DESCRIPTION
# What

Prints the Git Web URL for the current file at the current selection.
- Parses and constructs the remote Git URL
- Links to either the current line or a range with the current selection
- Uses `echomsg` to save the URL in the message-history

# Why

I have a common workflow where I'm investigating something in vim and then I want to send a link of what I'm looking at to someone. 

This change lets me run `:GitWebURL`, copy the URL, and then send it to someone (e.g. via slack). I can also cmd+click the URL which will open it in my browser.

I opted not to make a leader command for it since I'm not sure if it's useful to others. I also opted not to make it a plugin since it was easier to iterate in the vimrc. We can always extract it later if desired.

# Checklist

- [ ] Send RFC email to Braintree developers _if change may be impactful_. Please include a link to this PR so that disucssion about the pros and cons of the change remains linked to the proposed changes. **Recent examples include**: addition of linter and completer, no longer removing end-of-line whitespace on save, changing to fzf for file lookup.

I don't think this change is impactful enough to email everyone.

My vimscript is pretty weak, so please let me know if there are better ways to do this.