### PR TITLE
Add function for testing context

### DIFF
--- a/vim/ruby_mappings.vim
+++ b/vim/ruby_mappings.vim
@@ -1,3 +1,34 @@
+let s:context_start_pattern =
+    \ '\C^\s*#\@!\s*\%(RSpec\.\)\=\zs' .
+    \ '\<\%(module\|class\|if\|for\|while\|until\|case\|unless\|begin\|def' .
+    \ '\|\%(public\|protected\|private\)\=\s*def\):\@!\>' .
+    \ '\|\%(^\|[^.:@$]\)\@<=\<do:\@!\>'
+let s:context_end_pattern = '\%(^\|[^.:@$]\)\@<=\<end:\@!\>'
+let s:context_test_pattern =
+    \ '\C^\s*#\@!\s*\%(RSpec\.\)\=\zs' .
+    \ '\<\%(describe\|context\|shared_examples\|shared_context\)\>'
+
+function! TestContext()
+  wall
+  normal 0
+  let [_, lnum, cnum, _] = getpos('.')
+  if getline('.') !~ s:context_test_pattern
+    let prev_line = line('.')
+    while line('.') != 1
+      call searchpair(s:context_start_pattern, '', s:context_end_pattern, 'Wb')
+      if getline('.') =~ s:context_test_pattern || line('.') == prev_line
+        break
+      endif
+      let prev_line = line('.')
+    endwhile
+  endif
+  TestNearest
+  call cursor(lnum, cnum)
+endfunction
+
+command! TestContext :call TestContext()
+
+map <silent> <LocalLeader>rc :TestContext<CR>
 map <silent> <LocalLeader>rb :wa<CR> :TestFile<CR>
 map <silent> <LocalLeader>rf :wa<CR> :TestNearest<CR>
 map <silent> <LocalLeader>rl :wa<CR> :TestLast<CR>


### PR DESCRIPTION
# What

Add the ability to run `\rc` to run tests for a context.

# Why

The move to vim-test would remove the ability to run a test for a
context, this adds that back in. If run on a line that is a context
block, it will run that context as per the previous behavior.

## Technical Details
The regexes used here are based on the ones used in `vim-ruby` to find
nested 'class/module/do' + end blocks and navigate them properly. This
will find each parent block until it finds a test context or cannot find
a new parent.

Additionally, the `wall` function was moved inside the function because
on blank lines the `<CR>` would move down a line and that would change
the behavior.