### PR TITLE
Switch to extracted vim-github-url plugin

### DIFF
--- a/vimrc
+++ b/vimrc
@@ -277,17 +277,6 @@ endfunction
 command! -nargs=0 GitGrepWord :call GitGrepWord()
 nnoremap <silent> <Leader>gw :GitGrepWord<CR>
 
-function! GitHubURL() range
-  let branch = systemlist("git name-rev --name-only HEAD")[0]
-  let remote = systemlist("git config branch." . branch . ".remote")[0]
-  let repo = systemlist("git config --get remote." . remote . ".url | sed 's/\.git$//' | sed 's_^git@\\(.*\\):_https://\\1/_' | sed 's_^git://_https://_'")[0]
-  let revision = systemlist("git rev-parse HEAD")[0]
-  let path = systemlist("git ls-files --full-name " . @%)[0]
-  let url = repo . "/blob/" . revision . "/" . path . "#L" . a:firstline . "-L" . a:lastline
-  echomsg url
-endfunction
-command! -range GitHubURL <line1>,<line2>call GitHubURL()
-
 function! Trim()
   %s/\s*$//
   ''

--- a/vimrc.bundles
+++ b/vimrc.bundles
@@ -45,6 +45,7 @@ Plug 'mattn/emmet-vim'
 Plug 'mileszs/ack.vim'
 Plug 'nelstrom/vim-textobj-rubyblock'
 Plug 'pangloss/vim-javascript', { 'commit': 'ce0f529bbb938b42f757aeedbe8f5d95f095b51d' }
+Plug 'pgr0ss/vim-github-url'
 Plug 'rust-lang/rust.vim'
 Plug 'scrooloose/nerdtree'
 Plug 'tfnico/vim-gradle'


### PR DESCRIPTION
# What

Switch to extracted [vim-github-url](https://github.com/pgr0ss/vim-github-url) plugin.

# Why

GitHubURL has been extracted into a standalone plugin and improved.

For example, it now works with unpushed branches and random checked out commits: https://github.com/pgr0ss/vim-github-url/commit/1676bd367b55f2d4a90b0ca62fa674d32adae191

# Checklist

- [ ] Send RFC email to Braintree developers _if change may be impactful_. Please include a link to this PR so that disucssion about the pros and cons of the change remains linked to the proposed changes. **Recent examples include**: addition of linter and completer, no longer removing end-of-line whitespace on save, changing to fzf for file lookup.
