### PR TITLE
peg vim-ruby to the latest sha with unbroken syntax highlighting

### DIFF
--- a/vimrc.bundles
+++ b/vimrc.bundles
@@ -62,7 +62,7 @@ Plug 'tpope/vim-surround'
 Plug 'tpope/vim-unimpaired'
 Plug 'tpope/vim-vinegar'
 Plug 'uarun/vim-protobuf'
-Plug 'vim-ruby/vim-ruby', { 'commit': '074200ffa39b19baf9d9750d399d53d97f21ee07' }
+Plug 'vim-ruby/vim-ruby', { 'commit': '84565856e6965144e1c34105e03a7a7e87401acb' }
 Plug 'vim-scripts/Align'
 Plug 'vim-scripts/VimClojure'
 Plug 'vim-scripts/mako.vim'


### PR DESCRIPTION
Signed-off-by: Clayton Liggitt <clayton.liggitt@getbraintree.com>

# What

Fixes `vim-ruby` to the most recent sha where syntax highlighting works. When tpope fixes it, we can start following master or take the newest tag.

There were a [few commits](https://github.com/vim-ruby/vim-ruby/compare/84565856e6965144e1c34105e03a7a7e87401acb...8e9a78106681319b096bdc935eaeca308683bc10) working on this from 2017.

# Why
Ruby syntax highlighting for heredocs (specifically in gateway specs) has been broken on cpairs for a while.
