### PR TITLE
Add app/lib to rails_projections

### DIFF
--- a/vimrc
+++ b/vimrc
@@ -173,6 +173,9 @@ let g:rails_projections = {
       \   },
       \   "spec/script/*_spec.rb": {
       \     "alternate": "script/{}.rb"
+      \   },
+      \   "app/lib/*.rb": {
+      \     "test": "spec/lib/{}_spec.rb"
       \   }
       \ }
 


### PR DESCRIPTION
# What

Allows `:A` and `:R` to work with files in `app/lib`.

# Why

Currently, `spec/lib/foo_spec.rb` can alternate to `app/lib/foo.rb`, but not vice versa.

# Checklist

- [ ] Send RFC email to Braintree developers _if change may be impactful_. Please include a link to this PR so that disucssion about the pros and cons of the change remains linked to the proposed changes. **Recent examples include**: addition of linter and completer, no longer removing end-of-line whitespace on save, changing to fzf for file lookup.
