### PR TITLE
Include vim-graphql for editing GraphQL schema files.

### DIFF
--- a/vimrc.bundles
+++ b/vimrc.bundles
@@ -31,6 +31,7 @@ Plug 'jergason/scala.vim'
 Plug 'jgdavey/vim-turbux'
 Plug 'hashivim/vim-terraform'
 Plug 'jlanzarotta/bufexplorer', { 'commit': 'f3bbe12664b08038912faac586f6c0b5104325c3' }
+Plug 'jparise/vim-graphql', { 'commit': '7ecedede603d16de5cca5ccefbde14d642b0d697' }
 Plug 'jtratner/vim-flavored-markdown'
 if expand('<sfile>') == '/etc/vim/vimrc.bundles'
   Plug 'junegunn/fzf', { 'tag': '0.16.7', 'dir': '/etc/vim/fzf', 'do': './install --bin' }


### PR DESCRIPTION
# What

Includes [vim-graphql](https://github.com/jparise/vim-graphql) in the plugin bundles.

# Why

Currently, GraphQL schema files `.graphql`, `.graphqls` etc. are being treated as `conf` files. This change will allow us to edit schema files in a valid mode.

# Checklist

- [ ] Send RFC email to Braintree developers _if change may be impactful_. Please include a link to this PR so that disucssion about the pros and cons of the change remains linked to the proposed changes. **Recent examples include**: addition of linter and completer, no longer removing end-of-line whitespace on save, changing to fzf for file lookup.
