### PR TITLE
Use the function! syntax for defining MyTabLine and MyTabLabel

### DIFF
--- a/vimrc
+++ b/vimrc
@@ -328,7 +328,7 @@ endfunction
 " cleans up the way the default tabline looks
 " will show tab numbers next to the basename of the file
 " from :help setting-tabline
-function MyTabLine()
+function! MyTabLine()
   let s = ''
   for i in range(tabpagenr('$'))
     " select the highlighting
@@ -349,7 +349,7 @@ function MyTabLine()
 endfunction
 
 " with help from http://vim.wikia.com/wiki/Show_tab_number_in_your_tab_line
-function MyTabLabel(n)
+function! MyTabLabel(n)
   let buflist = tabpagebuflist(a:n)
   let winnr = tabpagewinnr(a:n)
   let bufnr = buflist[winnr - 1]


### PR DESCRIPTION
# What

Use the `function!` syntax when defining `MyTabLine` and `MyTabLabel`

# Why

`function <name>` will raise an error if the function already exists, but `function! <name>` will silently replace it. This allows me to `source $MYVIMRC` without having errors and without having to restart vim. Most of our functions are defined that way, so this is just keeping it consistent in addition to fixing the minor annoyance.

No RFC needed, this is minor change with no impact for most users.
