### PR TITLE
Add maralla completor for go

### DIFF
--- a/vimrc.bundles
+++ b/vimrc.bundles
@@ -20,6 +20,7 @@ Plug 'ekalinin/Dockerfile.vim'
 Plug 'elixir-lang/vim-elixir'
 Plug 'elubow/cql-vim'
 Plug 'fatih/vim-go', { 'do': ':GoInstallBinaries' }
+Plug 'maralla/completor.vim', { 'for': 'go' }
 Plug 'Glench/Vim-Jinja2-Syntax'
 Plug 'godlygeek/tabular' | Plug 'plasticboy/vim-markdown'
 Plug 'google/vim-jsonnet'


### PR DESCRIPTION
What
===
Add maralla completor.

Why
===
It is a really decent autocomplete plugin for go specifically, as it
uses gocode behind the scenes to find meaningful references to complete
on.

Notes
===
The plugin is only enabled when go files are loaded.

Please use the following structure when proposing changes to our shared Vim configuration and make sure to complete the checklist at the end.

Checklist
===
- [ ] ~Send RFC email to Braintree developers _if change may be impactful_. Please include a link to this PR so that disucssion about the pros and cons of the change remains linked to the proposed changes. **Recent examples include**: addition of linter and completer, no longer removing end-of-line whitespace on save, changing to fzf for file lookup.~
