### PR TITLE
Add ctrl-j/k navigation in popups

### DIFF
--- a/vimrc
+++ b/vimrc
@@ -369,6 +369,10 @@ function! MyTabLabel(n)
   return file
 endfunction
 
+" CTRL-J/K navigation in popups
+inoremap <expr> <c-j> (pumvisible()?"\<C-n>":"\<c-j>")
+inoremap <expr> <c-k> (pumvisible()?"\<C-p>":"\<c-k>")
+
 set tabline=%!MyTabLine()
 
 " ========= Aliases ========


### PR DESCRIPTION
What
===
Add ctrl-j/k navigation in popups.

Why
===
We use `jk` to navigate in normal mode. When a popup displays like for
autocompletion these lines will allow `ctrl` `jk` to navigate up and
down the list without needing to move hands to the arrow keys or to the
further away `np` keys.

Checklist
===

- [ ] ~Send RFC email to Braintree developers _if change may be impactful_. Please include a link to this PR so that disucssion about the pros and cons of the change remains linked to the proposed changes. **Recent examples include**: addition of linter and completer, no longer removing end-of-line whitespace on save, changing to fzf for file lookup.~
