### PR TITLE
Change VimuxRunLastCommand from \rl to \vl

### DIFF
--- a/vimrc
+++ b/vimrc
@@ -228,7 +228,7 @@ map <silent> <LocalLeader>cc :TComment<CR>
 map <silent> <LocalLeader>uc :TComment<CR>
 
 " Vimux
-map <silent> <LocalLeader>rl :wa<CR> :VimuxRunLastCommand<CR>
+map <silent> <LocalLeader>vl :wa<CR> :VimuxRunLastCommand<CR>
 map <silent> <LocalLeader>vi :wa<CR> :VimuxInspectRunner<CR>
 map <silent> <LocalLeader>vk :wa<CR> :VimuxInterruptRunner<CR>
 map <silent> <LocalLeader>vx :wa<CR> :VimuxClosePanes<CR>


### PR DESCRIPTION

# What

Change VimuxRunLastCommand from `\rl `to `\vl`

# Why

- This better aligns with other Vimux mappings that start with V
- This prevents it from colliding with the ruby override that changes `\rl`
to TestLast:
https://github.com/braintreeps/vim_dotfiles/blob/c0036eb49cc1933410d0fba8fb125b075b5b0fc9/vim/ruby_mappings.vim#L14-L14

