### PR TITLE
Add syntax highlighting plugin for JSX

### DIFF
--- a/vimrc.bundles
+++ b/vimrc.bundles
@@ -48,6 +48,7 @@ Plug 'mattn/emmet-vim'
 Plug 'mileszs/ack.vim'
 Plug 'nelstrom/vim-textobj-rubyblock'
 Plug 'pangloss/vim-javascript', { 'commit': 'ce0f529bbb938b42f757aeedbe8f5d95f095b51d' }
+Plug 'mxw/vim-jsx'
 Plug 'pgr0ss/vim-github-url'
 Plug 'rust-lang/rust.vim'
 Plug 'scrooloose/nerdtree'


### PR DESCRIPTION
# What

Adds a [syntax highlighting plugin](https://github.com/mxw/vim-jsx) for JSX. Note that this plugin is explicitly compatible with the JS syntax [highlighting plugin](https://github.com/pangloss/vim-javascript) already in use in this repo.

# Why

JSX highlighting is currently very much broken in ways described in [this Github issue](https://github.com/pangloss/vim-javascript/issues/242).

# Checklist

- [ ] Send RFC email to Braintree developers _if change may be impactful_. Please include a link to this PR so that disucssion about the pros and cons of the change remains linked to the proposed changes. **Recent examples include**: addition of linter and completer, no longer removing end-of-line whitespace on save, changing to fzf for file lookup.
