### PR TITLE
Add codefmt to format Bazel files using Buildifer.

### DIFF
--- a/vimrc
+++ b/vimrc
@@ -382,6 +382,12 @@ set tabline=%!MyTabLine()
 
 command! W w
 
+
+" Autoformat for bazel files
+augroup autoformat_settings
+  autocmd FileType bzl AutoFormatBuffer buildifier
+augroup END
+
 "-------- Local Overrides
 ""If you have options you'd like to override locally for
 "some reason (don't want to store something in a

--- a/vimrc.bundles
+++ b/vimrc.bundles
@@ -8,11 +8,12 @@ else
   call plug#begin('~/.vim/plugged')
 endif
 
+Plug 'google/vim-maktaba'
+Plug 'google/vim-codefmt'
 Plug 'benmills/vim-commadown'
 Plug 'benmills/vimux'
 Plug 'bkad/CamelCaseMotion'
 Plug 'chase/vim-ansible-yaml'
-Plug 'davidzchen/vim-bazel'
 Plug 'dewyze/vim-ruby-block-helpers'
 Plug 'ddrscott/vim-side-search'
 Plug 'derekwyatt/vim-scala'


### PR DESCRIPTION

# What
This PR makes it possible to format Bazel files using `buildifier` (https://github.com/bazelbuild/buildtools/tree/master/buildifier)

# Why

- Currently Bazel files are formatted using the plugin davidzchen/vim-bazel which is [deprecated](https://github.com/davidzchen/vim-bazel#vim-bazel-deprecated-please-use-googlevim-ft-bzl-instead).
- The plugin, while it was in use formatted files in an arbitrary, but consistent format.
- We intend to move to formatting Bazel files using Buildifier.

# Checklist

- [ ] Send RFC email to Braintree developers _if change may be impactful_. Please include a link to this PR so that disucssion about the pros and cons of the change remains linked to the proposed changes. **Recent examples include**: addition of linter and completer, no longer removing end-of-line whitespace on save, changing to fzf for file lookup.
