### PR TITLE
Remove references to inferior slime

### DIFF
--- a/vim/ruby_mappings.vim
+++ b/vim/ruby_mappings.vim
@@ -19,25 +19,5 @@ map <silent> <LocalLeader>AA   :A<CR>
 map <silent> <LocalLeader>AV   :AV<CR>
 map <silent> <LocalLeader>AS   :AS<CR>
 
-map <silent> <LocalLeader>sa :wa<CR> :InferiorSlimeSpecAll<CR>
-map <silent> <LocalLeader>sr :wa<CR> :InferiorSlimeRestart<CR>
-
-map <LocalLeader>ir :call _BounceInferiorSlime()<CR>
-
-function! _BounceInferiorSlime()
-  if _IsInferiorSlimeRunning()
-    call VimuxInterruptRunner()
-    call VimuxRunCommand("inferior-slime")
-  endif
-endfunction
-
-function! _IsInferiorSlimeRunning()
-  if system("ps axo command | grep inferior-slime | grep -v grep") == ""
-    return 0
-  else
-    return 1
-  end
-endfunction
-
 map <LocalLeader>rd Orequire "pry"; binding.pry<ESC>
 setlocal isk+=?


### PR DESCRIPTION
# What

Remove references to Inferior Slime.

# Why

Inferior Slime is a deprecated internal tool.
