### PR TITLE
Enable dotfiles for neovim

### DIFF
--- a/activate.sh
+++ b/activate.sh
@@ -3,6 +3,7 @@
 set -euo pipefail
 
 dotfiles_dir=$(cd "$(dirname "$0")"; pwd)
+mkdir -p "${HOME}/.config/nvim"
 
 if ! vim --version | grep -q '2nd user vimrc file'; then
   for name in vim vimrc vimrc.bundles; do
@@ -13,4 +14,8 @@ if ! vim --version | grep -q '2nd user vimrc file'; then
 else
   vim +qall
 fi
+for name in config/nvim/init.vim; do
+  rm -rf "${HOME}/.${name}"
+  ln -s "${dotfiles_dir}/${name}" "${HOME}/.${name}"
+done
 

--- a/config/nvim/init.vim
+++ b/config/nvim/init.vim
@@ -1,0 +1,3 @@
+    set runtimepath^=~/.vim runtimepath+=~/.vim/after
+    let &packpath = &runtimepath
+    source ~/.vimrc

--- a/vimrc
+++ b/vimrc
@@ -44,7 +44,9 @@ set smartcase
 set wildignore+=*.pyc,*.o,*.class,*.lo,.git,vendor/*,node_modules/**,bower_components/**,*/build_gradle/*,*/build_intellij/*,*/build/*,*/cassandra_data/*
 set tags+=gems.tags
 set mouse=
-set ttymouse=
+if !has('nvim')
+  set ttymouse=
+endif
 set backupcopy=yes " Setting backup copy preserves file inodes, which are needed for Docker file mounting
 if v:version > 704 || v:version == 704 && has('patch2201') " signcolumn wasn't added until vim 7.4.2201
   set signcolumn=yes


### PR DESCRIPTION
# What

This adds one compatibility if statement to not use ttymouse when in nvim and links and sets up nvim's directory for use with these dotfiles.  This should be entirely compatible with the previous usage, but just add nvim into the mix.

# Why

Why not use these dotfiles when using NeoVim?!?!