### PR TITLE
Add .github files to FZF fuzzy finder

### DIFF
--- a/vimrc
+++ b/vimrc
@@ -199,7 +199,7 @@ endif
 
 let g:puppet_align_hashes = 0
 
-let $FZF_DEFAULT_COMMAND = 'find * -type f 2>/dev/null | grep -v -E "deps/|_build/|node_modules/|vendor/"'
+let $FZF_DEFAULT_COMMAND = 'find * .github -type f 2>/dev/null | grep -v -E "deps/|_build/|node_modules/|vendor/"'
 let $FZF_DEFAULT_OPTS = '--reverse'
 let g:fzf_tags_command = 'ctags -R --exclude=".git\|.svn\|log\|tmp\|db\|pkg" --extra=+f --langmap=Lisp:+.clj'
 let g:fzf_action = {


### PR DESCRIPTION
# What

Add .github files to FZF fuzzy finder

# Why

It's nice to be able to fuzzy find PULL_REQUEST_TEMPLATE, CODEOWNERS, etc.

# Checklist

- [ ] ~Send RFC email to Braintree developers _if change may be impactful_. Please include a link to this PR so that discussion about the pros and cons of the change remains linked to the proposed changes. **Recent examples include**: addition of linter and completer, no longer removing end-of-line whitespace on save, changing to fzf for file lookup.~
