### PR TITLE
Ignore tmp, and fzf for hidden files

### DIFF
--- a/vimrc
+++ b/vimrc
@@ -172,7 +172,7 @@ let g:no_html_toolbar = 'yes'
 
 let coffee_no_trailing_space_error = 1
 
-let NERDTreeIgnore=['\.pyc$', '\.o$', '\.class$', '\.lo$']
+let NERDTreeIgnore=['\.pyc$', '\.o$', '\.class$', '\.lo$', 'tmp']
 let NERDTreeHijackNetrw = 0
 
 let g:netrw_banner = 0
@@ -200,7 +200,9 @@ endif
 
 let g:puppet_align_hashes = 0
 
-let $FZF_DEFAULT_COMMAND = 'find * .github -type f 2>/dev/null | grep -v -E "deps/|_build/|node_modules/|vendor/"'
+let $FZF_DEFAULT_COMMAND = 'find . -name "*" -type f 2>/dev/null                                                         
+                            \ | grep -v -E "tmp\/|.gitmodules|.git\/|deps\/|_build\/|node_modules\/|vendor\/"
+                            \ | sed "s|^\./||"'                                                                          
 let $FZF_DEFAULT_OPTS = '--reverse'
 let g:fzf_tags_command = 'ctags -R --exclude=".git\|.svn\|log\|tmp\|db\|pkg" --extra=+f --langmap=Lisp:+.clj'
 let g:fzf_action = {


### PR DESCRIPTION
# What

Ignore the `tmp` directory in nerdtree.

Use `find .` in fzf to search for all files, including hiddine ones. It
will ignore the .git directory (as well as tmp) and it uses a sed to
remove the leading `./` from the results so it looks the same as
`find *`.

# Why

We shouldn't need to navigate to the `tmp` folder usually, and if we do,
needing to do it via fzf clutters all of the fzf results.

Also, it can often be useful to find hidden files in fzf like
.rubocop or .rspec or similar other config files. By using `find *`
instead of `find .` we eliminate this. Additionally, `find *` can have
some weirdness depending on file names.