### PR TITLE
Use GFiles for fzf when possible

### DIFF
--- a/vimrc
+++ b/vimrc
@@ -229,7 +229,6 @@ map <silent> <LocalLeader>nf :NERDTreeFind<CR>
 " FZF
 function! SmartFuzzy()
   let root = split(system('git rev-parse --show-toplevel'), '\n')
-  echo "HERE"
   if len(root) == 0 || v:shell_error
     Files
   else

--- a/vimrc
+++ b/vimrc
@@ -227,21 +227,18 @@ map <silent> <LocalLeader>nr :NERDTree<CR>
 map <silent> <LocalLeader>nf :NERDTreeFind<CR>
 
 " FZF
-function! s:in_git_repo()
+function! SmartFuzzy()
   let root = split(system('git rev-parse --show-toplevel'), '\n')
+  echo "HERE"
   if len(root) == 0 || v:shell_error
-    return 0
+    Files
   else
-    return 1
-  end
+    GFiles -c -m -o --exclude-standard -- ':!:vendor/*' | sort
+  endif
 endfunction
 
-if s:in_git_repo()
-  map <silent> <leader>ff :GFiles -c -m -o --exclude-standard -- ':!:vendor/*' \| sort<CR>
-else
-  map <silent> <leader>ff :Files<CR>
-endif
-
+command! -nargs=* SmartFuzzy :call SmartFuzzy()
+map <silent> <leader>ff :SmartFuzzy<CR>
 map <silent> <leader>fg :GFiles<CR>
 map <silent> <leader>fb :Buffers<CR>
 map <silent> <leader>ft :Tags<CR>

--- a/vimrc
+++ b/vimrc
@@ -227,7 +227,21 @@ map <silent> <LocalLeader>nr :NERDTree<CR>
 map <silent> <LocalLeader>nf :NERDTreeFind<CR>
 
 " FZF
-map <silent> <leader>ff :Files<CR>
+function! s:in_git_repo()
+  let root = split(system('git rev-parse --show-toplevel'), '\n')
+  if len(root) == 0 || v:shell_error
+    return 0
+  else
+    return 1
+  end
+endfunction
+
+if s:in_git_repo()
+  map <silent> <leader>ff :GFiles -c -m -o --exclude-standard -- ':!:vendor/*' \| sort<CR>
+else
+  map <silent> <leader>ff :Files<CR>
+endif
+
 map <silent> <leader>fg :GFiles<CR>
 map <silent> <leader>fb :Buffers<CR>
 map <silent> <leader>ft :Tags<CR>

--- a/vimrc
+++ b/vimrc
@@ -233,7 +233,7 @@ function! SmartFuzzy()
   if len(root) == 0 || v:shell_error
     Files
   else
-    GFiles -c -m -o --exclude-standard -- ':!:vendor/*' | sort
+    GFiles -co --exclude-standard -- ':!:vendor/*'
   endif
 endfunction
 

--- a/vimrc.bundles
+++ b/vimrc.bundles
@@ -40,7 +40,7 @@ if expand('<sfile>') == '/etc/vim/vimrc.bundles'
 else
   Plug 'junegunn/fzf', { 'tag': '0.16.7', 'dir': '~/.fzf', 'do': './install --bin' }
 endif
-Plug 'junegunn/fzf.vim', {'commit': '990834ab6cb86961e61c55a8e012eb542ceff10e'}
+Plug 'junegunn/fzf.vim', {'commit': '741d7caabf229ec183364413f8b6d077a9939838'}
 Plug 'kana/vim-textobj-user'
 Plug 'kchmck/vim-coffee-script'
 Plug 'kien/rainbow_parentheses.vim'


### PR DESCRIPTION
# What/Why

Using `git ls-files` via `fzf#vim#gitfiles` is better because it will
respect the gitignore. However, we are not always in a gitrepo so we
need to check for that.

Additionally, this will ignore the vendor repo, because while it may be
not ignored, we don't really want to be fzf-ing through it.
