### PR TITLE
Remove long line highlighting

### DIFF
--- a/vimrc
+++ b/vimrc
@@ -97,11 +97,6 @@ endif
 autocmd InsertEnter * match ExtraWhitespace /\s\+\%#\@<!$/
 autocmd BufRead,InsertLeave * match ExtraWhitespace /\s\+$/
 
-" Highlight too-long lines
-autocmd BufRead,InsertEnter,InsertLeave * 2match LineLengthError /\%126v.*/
-highlight LineLengthError ctermbg=black guibg=black
-autocmd ColorScheme * highlight LineLengthError ctermbg=black guibg=black
-
 " Set up highlight group & retain through colorscheme changes
 highlight ExtraWhitespace ctermbg=red guibg=red
 autocmd ColorScheme * highlight ExtraWhitespace ctermbg=red guibg=red


### PR DESCRIPTION
# What

Remove long line highlighting

# Why

There are two issues with the current state:
- The highlight is black, so you can't see it if you use a black
background normally
- It overrides other highlighting such as spelling errors

There was an old PR to change it to red to make it more useful (#78) but
that was reverted due to "eye-bleeding" (#79).

This commit removes it instead.

Before:

![screen shot 2018-11-26 at 12 16 28 pm](https://user-images.githubusercontent.com/12998/49040589-9906b500-f188-11e8-8e22-06395a45cf54.png)

After:

![screen shot 2018-11-26 at 12 17 48 pm](https://user-images.githubusercontent.com/12998/49040598-9e63ff80-f188-11e8-8f8e-6171e3640e66.png)

# Checklist

- ~~[ ] Send RFC email to Braintree developers _if change may be impactful_. Please include a link to this PR so that discussion about the pros and cons of the change remains linked to the proposed changes.~~ Given that the highlighting is not working for many (most?) people, this doesn't seem too impactful.