### PR TITLE
Remove missed reference to inferior slime

### DIFF
--- a/vimrc
+++ b/vimrc
@@ -195,9 +195,9 @@ endif
 
 let g:puppet_align_hashes = 0
 
-let $FZF_DEFAULT_COMMAND = 'find . -name "*" -type f 2>/dev/null                                                         
+let $FZF_DEFAULT_COMMAND = 'find . -name "*" -type f 2>/dev/null
                             \ | grep -v -E "tmp\/|.gitmodules|.git\/|deps\/|_build\/|node_modules\/|vendor\/"
-                            \ | sed "s|^\./||"'                                                                          
+                            \ | sed "s|^\./||"'
 let $FZF_DEFAULT_OPTS = '--reverse'
 let g:fzf_tags_command = 'ctags -R --exclude=".git\|.svn\|log\|tmp\|db\|pkg" --extra=+f --langmap=Lisp:+.clj'
 let g:fzf_action = {
@@ -316,12 +316,6 @@ function! Trim()
 endfunction
 command! -nargs=0 Trim :call Trim()
 nnoremap <silent> <Leader>cw :Trim<CR>
-
-function! StartInferiorSlimeServer()
-  let g:__InferiorSlimeRunning = 1
-  call VimuxRunCommand("inferior-slime")
-endfunction
-command! -nargs=0 StartInferiorSlimeServer :call StartInferiorSlimeServer()
 
 function! __Edge()
   colorscheme Tomorrow-Night


### PR DESCRIPTION
# What

a65acc7 removed references to Inferior Slime, but missed this one.

# Why

Inferior Slime is a deprecated internal tool.