### PR TITLE
Enable rubocop linting on ruby files

### DIFF
--- a/vimrc
+++ b/vimrc
@@ -148,8 +148,8 @@ vnoremap * :<C-u>call <SID>VSetSearch()<CR>/<CR>
 let g:ale_enabled = 1                     " Enable linting by default
 let g:ale_lint_on_text_changed = 'normal' " Only lint while in normal mode
 let g:ale_lint_on_insert_leave = 1        " Automatically lint when leaving insert mode
-
-let g:ale_linters_explicit = 1
+let g:ale_set_signs = 0                   " Disable signs showing in the gutter to reduce interruptive visuals
+let g:ale_linters_explicit = 1            " Only run linters that are explicitly listed below
 let g:ale_linters = {}
 if filereadable(expand(".rubocop.yml"))
   let g:ale_linters['ruby'] = ['rubocop']

--- a/vimrc
+++ b/vimrc
@@ -145,12 +145,13 @@ endfunction
 
 vnoremap * :<C-u>call <SID>VSetSearch()<CR>/<CR>
 
-let g:ale_enabled = 0                     " Disable linting by default
+let g:ale_enabled = 1                     " Disable linting by default
 let g:ale_lint_on_text_changed = 'normal' " Only lint while in normal mode
 let g:ale_lint_on_insert_leave = 1        " Automatically lint when leaving insert mode
 
+let g:ale_linters_explicit = 1
 let g:ale_linters = {
-\   'java': []
+\   'ruby': ['rubocop']
 \ }
 
 let html_use_css=1

--- a/vimrc
+++ b/vimrc
@@ -150,9 +150,10 @@ let g:ale_lint_on_text_changed = 'normal' " Only lint while in normal mode
 let g:ale_lint_on_insert_leave = 1        " Automatically lint when leaving insert mode
 
 let g:ale_linters_explicit = 1
-let g:ale_linters = {
-\   'ruby': ['rubocop']
-\ }
+let g:ale_linters = {}
+if filereadable(expand(".rubocop.yml"))
+  let g:ale_linters['ruby'] = ['rubocop']
+endif
 
 let html_use_css=1
 let html_number_lines=0

--- a/vimrc
+++ b/vimrc
@@ -145,7 +145,7 @@ endfunction
 
 vnoremap * :<C-u>call <SID>VSetSearch()<CR>/<CR>
 
-let g:ale_enabled = 1                     " Disable linting by default
+let g:ale_enabled = 1                     " Enable linting by default
 let g:ale_lint_on_text_changed = 'normal' " Only lint while in normal mode
 let g:ale_lint_on_insert_leave = 1        " Automatically lint when leaving insert mode
 


### PR DESCRIPTION
### What
Enable the `ruby` `rubocop` linter if there's a `.rubocop.yml` file present, specify that the only linters that should run are the ones explicitly enabled, and configure the plugin so that it causes minimal visual distractions by disabling the gutter leaving a dim highlight on violations as the only visual signal of a violation.

### Why
We've got ale disabled but we're making use of `rubocop`. I and others waste time by pushing changes to a PR, waiting for tests to run, discovering rubocop violations, fixing, repushing. `rubocop` and `ale` are fast and they'd provide us with feedback immediately.

The changes also disable the gutter (the bright icons that normally display in the left bar) so that the only visual signal of violations will be blue background highlighting on the violation itself. This is clear enough that it can't be missed while ensuring ale is not a distracting/jarring visual experience. Moving the cursor over the highlighted text will display a message in the status line calling out what's wrong.

Ale also runs a lot of linters by default. We have the java ones disabled at the moment, but really we should be explicit and enable just the linters we actually need. Folks can enable other linters they explicitly want to use in `vimrc_local`.

# Checklist

- [ ] Send RFC email to Braintree developers _if change may be impactful_.