### PR TITLE
Make our vim java indents more consistent with IntelliJ

### DIFF
--- a/after/indent/java.vim
+++ b/after/indent/java.vim
@@ -1,0 +1,1 @@
+set cinoptions=+1s,(0,W1s

--- a/after/indent/java.vim
+++ b/after/indent/java.vim
@@ -1,1 +1,1 @@
-set cinoptions=+1s,(0,W1s
+set cinoptions+=+1s,(0,W1s

--- a/vimrc
+++ b/vimrc
@@ -81,7 +81,7 @@ autocmd FileType php setlocal tabstop=4 shiftwidth=4 softtabstop=4
 autocmd FileType python setlocal tabstop=4 shiftwidth=4 softtabstop=4
 autocmd FileType cs setlocal tabstop=4 shiftwidth=4 softtabstop=4
 
-if filereadable(expand('.ijwd'))
+if isdirectory(expand('.ijwb'))
   autocmd FileType java setlocal tabstop=2 shiftwidth=2 softtabstop=2
 else
   autocmd FileType java setlocal tabstop=4 shiftwidth=4 softtabstop=4

--- a/vimrc
+++ b/vimrc
@@ -79,7 +79,7 @@ augroup END
 
 autocmd FileType php setlocal tabstop=4 shiftwidth=4 softtabstop=4
 autocmd FileType python setlocal tabstop=4 shiftwidth=4 softtabstop=4
-autocmd FileType java setlocal tabstop=4 shiftwidth=4 softtabstop=4
+autocmd FileType java setlocal expandtab tabstop=2 shiftwidth=2 softtabstop=2
 autocmd FileType cs setlocal tabstop=4 shiftwidth=4 softtabstop=4
 
 autocmd FileType tex setlocal textwidth=78

--- a/vimrc
+++ b/vimrc
@@ -79,8 +79,13 @@ augroup END
 
 autocmd FileType php setlocal tabstop=4 shiftwidth=4 softtabstop=4
 autocmd FileType python setlocal tabstop=4 shiftwidth=4 softtabstop=4
-autocmd FileType java setlocal textwidth=120
 autocmd FileType cs setlocal tabstop=4 shiftwidth=4 softtabstop=4
+
+if filereadable(expand('.ijwd'))
+  autocmd FileType java setlocal tabstop=2 shiftwidth=2 softtabstop=2
+else
+  autocmd FileType java setlocal tabstop=4 shiftwidth=4 softtabstop=4
+endif
 
 autocmd FileType tex setlocal textwidth=78
 autocmd BufNewFile,BufRead *.txt setlocal textwidth=78

--- a/vimrc
+++ b/vimrc
@@ -79,7 +79,7 @@ augroup END
 
 autocmd FileType php setlocal tabstop=4 shiftwidth=4 softtabstop=4
 autocmd FileType python setlocal tabstop=4 shiftwidth=4 softtabstop=4
-autocmd FileType java setlocal expandtab tabstop=2 shiftwidth=2 softtabstop=2
+autocmd FileType java setlocal textwidth=120
 autocmd FileType cs setlocal tabstop=4 shiftwidth=4 softtabstop=4
 
 autocmd FileType tex setlocal textwidth=78

--- a/vimrc
+++ b/vimrc
@@ -81,10 +81,10 @@ autocmd FileType php setlocal tabstop=4 shiftwidth=4 softtabstop=4
 autocmd FileType python setlocal tabstop=4 shiftwidth=4 softtabstop=4
 autocmd FileType cs setlocal tabstop=4 shiftwidth=4 softtabstop=4
 
-if isdirectory(expand('.ijwb'))
-  autocmd FileType java setlocal tabstop=2 shiftwidth=2 softtabstop=2
-else
+if fnamemodify(getcwd(), ':t') == 'braintree-java'
   autocmd FileType java setlocal tabstop=4 shiftwidth=4 softtabstop=4
+else
+  autocmd FileType java setlocal tabstop=2 shiftwidth=2 softtabstop=2
 endif
 
 autocmd FileType tex setlocal textwidth=78


### PR DESCRIPTION
### What
Make our vim java indents more consistent with IntelliJ by:
- `tabstop=2 shiftwidth=2 softtabstop=2`: tabs are 2 spaces
- `cinoptions` `+1s`: continuation indents are 1x shiftwidth (i.e. 2 spaces)
- `cinoptions` `(0`: continuation indents in function argument lists align on new lines
- `cinoptions` `W1s`: continuation indents in function argument where the
first item is on the next line fallback to standard continuation
indenting

### Why
Writing java in our vim config is significantly different to our
IntelliJ config. These changes make some basic improvements, more are
needed, but this makes vim do the right thing in many more cases than
it does now.

### Checklist
- [ ] ~Send RFC email to Braintree developers _if change may be impactful_. Please include a link to this PR so that discussion about the pros and cons of the change remains linked to the proposed changes. **Recent examples include**: addition of linter and completer, no longer removing end-of-line whitespace on save, changing to fzf for file lookup.~
