### PR TITLE
Add vim-test custom runner for java projects using bazel

### DIFF
--- a/autoload/test/java/bazeltest.vim
+++ b/autoload/test/java/bazeltest.vim
@@ -1,0 +1,55 @@
+if !exists('g:test#java#bazeltest#executable')
+  let g:test#java#bazeltest#executable = 'bazel'
+endif
+
+if !exists('g:test#java#bazeltest#file_pattern')
+  let g:test#java#bazeltest#file_pattern = g:test#java#maventest#file_pattern
+endif
+
+function! test#java#bazeltest#test_file(file) abort
+  return a:file =~? g:test#java#bazeltest#file_pattern
+    \ && exists('g:test#java#runner')
+    \ && g:test#java#runner ==# 'bazeltest'
+endfunction
+
+function! test#java#bazeltest#executable() abort
+  return g:test#java#bazeltest#executable
+endfunction
+
+function! test#java#bazeltest#build_args(args) abort
+  return ['test'] + a:args
+endfunction
+
+function! test#java#bazeltest#build_position(type, position) abort
+  let file = a:position['file']
+  let target = s:bazel_target(file)
+
+  if a:type ==# 'nearest'
+    let nearest = test#base#nearest_test(a:position, g:test#java#patterns)
+    let classname = get(nearest['namespace'], 0, '')
+    let testname = get(nearest['test'], 0, '')
+    let filter = join([classname] + [testname], '#')
+    if !empty(filter)
+      return [target, '--test_filter=' . filter]
+    endif
+  endif
+
+  if a:type ==# 'nearest' || a:type ==# 'file'
+    let classname = fnamemodify(file, ':t:r')
+    return [target, '--test_filter=' . classname]
+  endif
+
+  return [target]
+endfunction
+
+function! s:bazel_target(file) abort
+  let package = s:bazel_command('query --output=package ' . a:file)
+  let label = s:bazel_command('query --output=label ' . a:file)
+  let target = s:bazel_command('query ''attr("srcs", "' . label . '", "//' . package . ':*")''')
+  return target
+endfunction
+
+function! s:bazel_command(args) abort
+  let output = system(g:test#java#bazeltest#executable . ' ' . a:args . ' 2> /dev/null')
+  return substitute(output, '\n$', '', '')
+endfunction

--- a/autoload/test/java/bazeltest.vim
+++ b/autoload/test/java/bazeltest.vim
@@ -32,7 +32,7 @@ function! test#java#bazeltest#build_position(type, position) abort
     let nearest = test#base#nearest_test(a:position, g:test#java#patterns)
     let classname = get(nearest['namespace'], 0, '')
     let testname = get(nearest['test'], 0, '')
-    let filter = join([classname] + [testname], '#')
+    let filter = join([classname, testname], '#')
     if !empty(filter)
       return [target, '--test_filter=' . filter]
     endif

--- a/autoload/test/java/bazeltest.vim
+++ b/autoload/test/java/bazeltest.vim
@@ -32,7 +32,7 @@ function! test#java#bazeltest#build_position(type, position) abort
     let nearest = test#base#nearest_test(a:position, g:test#java#patterns)
     let classname = get(nearest['namespace'], 0, '')
     let testname = get(nearest['test'], 0, '')
-    let filter = join([classname, testname], '#')
+    let filter = join([classname, testname], '#') . '$'
     if !empty(filter)
       return [target, '--test_filter=' . filter]
     endif

--- a/autoload/test/java/bazeltest.vim
+++ b/autoload/test/java/bazeltest.vim
@@ -1,5 +1,9 @@
-if !exists('g:test#java#bazeltest#executable')
-  let g:test#java#bazeltest#executable = 'bazel'
+if !exists('g:test#java#bazeltest#test_executable')
+  let g:test#java#bazeltest#test_executable = 'bazel test'
+endif
+
+if !exists('g:test#java#bazeltest#query_executable')
+  let g:test#java#bazeltest#query_executable = 'bazel query'
 endif
 
 if !exists('g:test#java#bazeltest#file_pattern')
@@ -13,11 +17,11 @@ function! test#java#bazeltest#test_file(file) abort
 endfunction
 
 function! test#java#bazeltest#executable() abort
-  return g:test#java#bazeltest#executable
+  return g:test#java#bazeltest#test_executable
 endfunction
 
 function! test#java#bazeltest#build_args(args) abort
-  return ['test'] + a:args
+  return a:args
 endfunction
 
 function! test#java#bazeltest#build_position(type, position) abort
@@ -43,13 +47,13 @@ function! test#java#bazeltest#build_position(type, position) abort
 endfunction
 
 function! s:bazel_target(file) abort
-  let package = s:bazel_command('query --output=package ' . a:file)
-  let label = s:bazel_command('query --output=label ' . a:file)
-  let target = s:bazel_command('query ''attr("srcs", "' . label . '", "//' . package . ':*")''')
+  let package = s:bazel_query('--output=package ' . a:file)
+  let label = s:bazel_query('--output=label ' . a:file)
+  let target = s:bazel_query('''attr("srcs", "' . label . '", "//' . package . ':*")''')
   return target
 endfunction
 
-function! s:bazel_command(args) abort
-  let output = system(g:test#java#bazeltest#executable . ' ' . a:args . ' 2> /dev/null')
+function! s:bazel_query(args) abort
+  let output = system(g:test#java#bazeltest#query_executable . ' ' . a:args . ' 2> /dev/null')
   return substitute(output, '\n$', '', '')
 endfunction

--- a/java_mappings.vim
+++ b/java_mappings.vim
@@ -1,4 +1,3 @@
-map <silent> <LocalLeader>rc :TestContext<CR>
 map <silent> <LocalLeader>rb :wa<CR> :TestFile<CR>
 map <silent> <LocalLeader>rf :wa<CR> :TestNearest<CR>
 map <silent> <LocalLeader>rl :wa<CR> :TestLast<CR>

--- a/java_mappings.vim
+++ b/java_mappings.vim
@@ -1,0 +1,4 @@
+map <silent> <LocalLeader>rc :TestContext<CR>
+map <silent> <LocalLeader>rb :wa<CR> :TestFile<CR>
+map <silent> <LocalLeader>rf :wa<CR> :TestNearest<CR>
+map <silent> <LocalLeader>rl :wa<CR> :TestLast<CR>

--- a/java_mappings.vim
+++ b/java_mappings.vim
@@ -1,3 +1,4 @@
+map <silent> <LocalLeader>rs :wa<CR> :TestSuite<CR>
 map <silent> <LocalLeader>rb :wa<CR> :TestFile<CR>
 map <silent> <LocalLeader>rf :wa<CR> :TestNearest<CR>
 map <silent> <LocalLeader>rl :wa<CR> :TestLast<CR>

--- a/vimrc
+++ b/vimrc
@@ -216,6 +216,7 @@ let test#strategy = "vimux"
 let test#custom_runners = {'java': ['bazeltest']}
 let test#python#runner = 'nose'
 let test#java#runner = 'bazeltest'
+let g:test#java#bazeltest#test_executable = './bazel test'
 
 " ========= Shortcuts ========
 

--- a/vimrc
+++ b/vimrc
@@ -220,6 +220,7 @@ if filereadable(expand('WORKSPACE'))
   let test#custom_runners['java'] = ['bazeltest']
   let test#java#runner = 'bazeltest'
   let g:test#java#bazeltest#test_executable = './bazel test'
+  let g:test#java#bazeltest#file_pattern = '.*/test/.*\.java$'
 endif
 
 " ========= Shortcuts ========

--- a/vimrc
+++ b/vimrc
@@ -213,10 +213,14 @@ let g:go_fmt_command = "goimports"
 let g:go_highlight_trailing_whitespace_error = 0
 
 let test#strategy = "vimux"
-let test#custom_runners = {'java': ['bazeltest']}
+let test#custom_runners = {}
 let test#python#runner = 'nose'
-let test#java#runner = 'bazeltest'
-let g:test#java#bazeltest#test_executable = './bazel test'
+
+if filereadable(expand('WORKSPACE'))
+  let test#custom_runners['java'] = ['bazeltest']
+  let test#java#runner = 'bazeltest'
+  let g:test#java#bazeltest#test_executable = './bazel test'
+endif
 
 " ========= Shortcuts ========
 

--- a/vimrc
+++ b/vimrc
@@ -87,6 +87,7 @@ autocmd BufNewFile,BufRead *.txt setlocal textwidth=78
 
 autocmd FileType ruby runtime ruby_mappings.vim
 autocmd FileType python runtime python_mappings.vim
+autocmd FileType java runtime java_mappings.vim
 
 if version >= 700
     autocmd BufNewFile,BufRead *.txt setlocal spell spelllang=en_us
@@ -212,7 +213,9 @@ let g:go_fmt_command = "goimports"
 let g:go_highlight_trailing_whitespace_error = 0
 
 let test#strategy = "vimux"
+let test#custom_runners = {'java': ['bazeltest']}
 let test#python#runner = 'nose'
+let test#java#runner = 'bazeltest'
 
 " ========= Shortcuts ========
 


### PR DESCRIPTION
### What
Add vim-test custom runner for java projects using bazel that runs the
test underneath the cursor, or all the tests in the current buffers
class.

### Why
To make running java tests when in vim easier.

### Notes
- The runner uses bazel query to dig up the appropriate target for the
file that is open. At the moment it requires 3 separate calls to bazel,
and I'm looking into how to reduce that to 1.
- The runner pipes the results of bazel commands stderr to /dev/null
because bazel does not support anyway of turning off INFO and DEBUG
error logs yet.

### Checklist

- [ ] ~Send RFC email to Braintree developers _if change may be impactful_. Please include a link to this PR so that discussion about the pros and cons of the change remains linked to the proposed changes. **Recent examples include**: addition of linter and completer, no longer removing end-of-line whitespace on save, changing to fzf for file lookup.~