### PR TITLE
Remove unused imports in Java files

### DIFF
--- a/vimrc
+++ b/vimrc
@@ -214,6 +214,9 @@ let g:go_highlight_trailing_whitespace_error = 0
 let test#strategy = "vimux"
 let test#python#runner = 'nose'
 
+" Remove unused imports for Java
+autocmd FileType java autocmd BufWritePost * :UnusedImportsRemove
+
 " ========= Shortcuts ========
 
 " NERDTree

--- a/vimrc
+++ b/vimrc
@@ -215,7 +215,7 @@ let test#strategy = "vimux"
 let test#python#runner = 'nose'
 
 " Remove unused imports for Java
-autocmd FileType java autocmd BufWritePost * :UnusedImportsRemove
+autocmd FileType java autocmd BufWritePre * :UnusedImportsRemove
 
 " ========= Shortcuts ========
 

--- a/vimrc.bundles
+++ b/vimrc.bundles
@@ -8,6 +8,7 @@ else
   call plug#begin('~/.vim/plugged')
 endif
 
+Plug 'akhaku/vim-java-unused-imports'
 Plug 'google/vim-maktaba'
 Plug 'google/vim-codefmt'
 Plug 'benmills/vim-commadown'
@@ -75,7 +76,6 @@ Plug 'vim-scripts/groovyindent-unix'
 Plug 'vim-scripts/mako.vim'
 Plug 'vim-scripts/matchit.zip'
 Plug 'voxpupuli/vim-puppet', { 'commit': 'e88c19bf10763b30f86b7417677f59a9c9487fa2' }
-Plug 'akhaku/vim-java-unused-imports'
 
 if v:version >= 800 || has('nvim')
   Plug 'w0rp/ale'

--- a/vimrc.bundles
+++ b/vimrc.bundles
@@ -75,6 +75,7 @@ Plug 'vim-scripts/groovyindent-unix'
 Plug 'vim-scripts/mako.vim'
 Plug 'vim-scripts/matchit.zip'
 Plug 'voxpupuli/vim-puppet', { 'commit': 'e88c19bf10763b30f86b7417677f59a9c9487fa2' }
+Plug 'akhaku/vim-java-unused-imports'
 
 if v:version >= 800 || has('nvim')
   Plug 'w0rp/ale'


### PR DESCRIPTION
### What
Remove unused imports in Java files when saving the file.

### Why
To keep the list of imports relevant to the code in the file, and to
align with our IntelliJ config.

### Checklist

- [ ] ~Send RFC email to Braintree developers _if change may be impactful_. Please include a link to this PR so that discussion about the pros and cons of the change remains linked to the proposed changes. **Recent examples include**: addition of linter and completer, no longer removing end-of-line whitespace on save, changing to fzf for file lookup.~
