### PR TITLE
Add vim-yaml-helper

### DIFF
--- a/vimrc
+++ b/vimrc
@@ -294,6 +294,9 @@ map <silent> <LocalLeader>ws :highlight clear ExtraWhitespace<CR>
 
 map <silent> <LocalLeader>pp :set paste!<CR>
 
+" YAML
+let g:vim_yaml_helper#auto_display_path = 1
+
 " Pasting over a selection does not replace the clipboard
 xnoremap <expr> p 'pgv"'.v:register.'y'
 

--- a/vimrc
+++ b/vimrc
@@ -51,6 +51,7 @@ if v:version > 704 || v:version == 704 && has('patch2201') " signcolumn wasn't a
   set signcolumn=yes
 endif
 set complete-=t " Don't use tags for autocomplete
+set updatetime=200
 
 if version >= 703
   set undodir=~/.vim/undodir

--- a/vimrc.bundles
+++ b/vimrc.bundles
@@ -45,6 +45,7 @@ Plug 'junegunn/fzf.vim', {'commit': '741d7caabf229ec183364413f8b6d077a9939838'}
 Plug 'kana/vim-textobj-user'
 Plug 'kchmck/vim-coffee-script'
 Plug 'kien/rainbow_parentheses.vim'
+Plug 'lmeijvogel/vim-yaml-helper', { 'commit': 'db031682d339f361e2f8ed213cdb2c505cd0e011' }
 Plug 'markcornick/vim-bats'
 Plug 'mattn/emmet-vim'
 Plug 'mileszs/ack.vim'

--- a/vimrc.bundles
+++ b/vimrc.bundles
@@ -45,7 +45,7 @@ Plug 'junegunn/fzf.vim', {'commit': '741d7caabf229ec183364413f8b6d077a9939838'}
 Plug 'kana/vim-textobj-user'
 Plug 'kchmck/vim-coffee-script'
 Plug 'kien/rainbow_parentheses.vim'
-Plug 'lmeijvogel/vim-yaml-helper', { 'commit': 'db031682d339f361e2f8ed213cdb2c505cd0e011' }
+Plug 'lmeijvogel/vim-yaml-helper'
 Plug 'markcornick/vim-bats'
 Plug 'mattn/emmet-vim'
 Plug 'mileszs/ack.vim'


### PR DESCRIPTION
### What
Add vim-yaml-helper plugin and configure it to display in the status
line the full path to the key under the cursor.

### Why
Looking at really large YAML files it can be difficult to see what the
root node or full path is without doing a lot of scrolling. This helps
us navigate large YAML files.

# Checklist

- [ ] ~Send RFC email to Braintree developers _if change may be impactful_. Please include a link to this PR so that discussion about the pros and cons of the change remains linked to the proposed changes. **Recent examples include**: addition of linter and completer, no longer removing end-of-line whitespace on save, changing to fzf for file lookup.~
