### PR TITLE
Support multiple targets when running bazel tests

### DIFF
--- a/autoload/test/java/bazeltest.vim
+++ b/autoload/test/java/bazeltest.vim
@@ -49,7 +49,7 @@ endfunction
 function! s:bazel_target(file) abort
   let package = s:bazel_query('--output=package ' . a:file)
   let label = s:bazel_query('--output=label ' . a:file)
-  let target = s:bazel_query('''attr("srcs", "' . label . '", "//' . package . ':*")''')
+  let target = substitute(s:bazel_query('''attr("srcs", "' . label . '", "//' . package . ':*")'''), '\n', ' ', 'g')
   return target
 endfunction
 


### PR DESCRIPTION
### What
Support multiple targets when running bazel tests by running the test on
any target that the test is executable within.

### Why
A test file can exist in multiple targets. If that's the case bazel
query returns the list of targets new line separated. We can pass
multiple targets to bazel test and it will run the test once for each
target. Without this change the command has a new line in it and it runs
the tests for the suite and then outputs other stuff into the terminal.

# Checklist

- [ ] ~Send RFC email to Braintree developers _if change may be impactful_. Please include a link to this PR so that discussion about the pros and cons of the change remains linked to the proposed changes. **Recent examples include**: addition of linter and completer, no longer removing end-of-line whitespace on save, changing to fzf for file lookup.~
