### PR TITLE
Only highlight do not remove unused imports

### DIFF
--- a/vimrc
+++ b/vimrc
@@ -230,7 +230,7 @@ if filereadable(expand('WORKSPACE'))
 endif
 
 " Remove unused imports for Java
-autocmd FileType java autocmd BufWritePre * :UnusedImportsRemove
+autocmd FileType java autocmd BufWritePre * :UnusedImports
 
 " ========= Shortcuts ========
 


### PR DESCRIPTION
### What
Only highlight do not remove unused java imports.

### Why
The plugin we're using doesn't seem to handle all cases and we've seen
some cases where imports have been removed when they shouldn't be. This
will bring us the benefits of seeing unused imports clearly in the
majority of cases and won't interfere with cases where they are still
being used. Maybe we can add this back when the plugin doesn't have this
bug.