### PR TITLE
ale: enable puppet-lint

### DIFF
--- a/vimrc
+++ b/vimrc
@@ -158,6 +158,7 @@ let g:ale_lint_on_insert_leave = 1        " Automatically lint when leaving inse
 let g:ale_set_signs = 0                   " Disable signs showing in the gutter to reduce interruptive visuals
 let g:ale_linters_explicit = 1            " Only run linters that are explicitly listed below
 let g:ale_linters = {}
+let g:ale_linters['puppet'] = ['puppetlint']
 if filereadable(expand(".rubocop.yml"))
   let g:ale_linters['ruby'] = ['rubocop']
 endif


### PR DESCRIPTION
# What

enable puppet-lint

# Why

puppet-lint has a handful of useful linting options, we added a very
conservative whitelist to our puppet repo, so lets enable it by default.