### PR TITLE
Do not highlight trailing whitespace by default

### DIFF
--- a/vimrc
+++ b/vimrc
@@ -100,7 +100,7 @@ autocmd FileType java runtime java_mappings.vim
 let g:wstrip_highlight = 0
 " strip trailing whitespace on save for any lines modified for the following
 " languages
-autocmd FileType ruby,java,pyhon,c,cpp,sql,puppet let b:wstrip_auto = 1
+autocmd FileType ruby,java,python,c,cpp,sql,puppet let b:wstrip_auto = 1
 
 if version >= 700
     autocmd BufNewFile,BufRead *.txt setlocal spell spelllang=en_us

--- a/vimrc
+++ b/vimrc
@@ -95,6 +95,13 @@ autocmd FileType ruby runtime ruby_mappings.vim
 autocmd FileType python runtime python_mappings.vim
 autocmd FileType java runtime java_mappings.vim
 
+" wstrip plugin
+" don't highlight trailing whitespace
+let g:wstrip_highlight = 0
+" strip trailing whitespace on save for any lines modified for the following
+" languages
+autocmd FileType ruby,java,pyhon,c,cpp,sql,puppet let b:wstrip_auto = 1
+
 if version >= 700
     autocmd BufNewFile,BufRead *.txt setlocal spell spelllang=en_us
     autocmd FileType tex setlocal spell spelllang=en_us

--- a/vimrc
+++ b/vimrc
@@ -100,14 +100,6 @@ if version >= 700
     autocmd FileType tex setlocal spell spelllang=en_us
 endif
 
-" Highlight trailing whitespace
-autocmd InsertEnter * match ExtraWhitespace /\s\+\%#\@<!$/
-autocmd BufRead,InsertLeave * match ExtraWhitespace /\s\+$/
-
-" Set up highlight group & retain through colorscheme changes
-highlight ExtraWhitespace ctermbg=red guibg=red
-autocmd ColorScheme * highlight ExtraWhitespace ctermbg=red guibg=red
-
 " Run terraform fmt on terraform files
 autocmd BufWritePre *.tf call terraform#fmt()
 
@@ -294,7 +286,8 @@ nnoremap <silent> k gk
 nnoremap <silent> j gj
 nnoremap <silent> Y y$
 
-map <silent> <LocalLeader>ws :highlight clear ExtraWhitespace<CR>
+" search for trailing whitespace
+map <silent> <LocalLeader>ws /\s\+$<CR>
 
 map <silent> <LocalLeader>pp :set paste!<CR>
 

--- a/vimrc.bundles
+++ b/vimrc.bundles
@@ -76,6 +76,9 @@ Plug 'vim-scripts/groovyindent-unix'
 Plug 'vim-scripts/mako.vim'
 Plug 'vim-scripts/matchit.zip'
 Plug 'voxpupuli/vim-puppet', { 'commit': 'e88c19bf10763b30f86b7417677f59a9c9487fa2' }
+" use diff-error branch until the PR is merged into master, as it fixes wstrip
+" usage outside of git repos
+Plug 'tweekmonster/wstrip.vim', { 'branch': 'diff-error' }
 
 if v:version >= 800 || has('nvim')
   Plug 'w0rp/ale'


### PR DESCRIPTION
Trailing whitespace, though perhaps annoying to some developers is
harmless in almost any language. Our current config highlights trailing
whitespace in red, which makes it more difficult to read documents that
happen to have trailing whitespace, or in markdown files where it is
used when grouping paragraphs.

This commit disables highlighting by default and flips the shortcut to
highlight trailing whitespace, rather than clear it.