### PR TITLE
sets expandtabs for python files

### DIFF
--- a/vimrc
+++ b/vimrc
@@ -79,7 +79,7 @@ augroup END
 " File Types
 
 autocmd FileType php setlocal tabstop=4 shiftwidth=4 softtabstop=4
-autocmd FileType python setlocal tabstop=4 shiftwidth=4 softtabstop=4
+autocmd FileType python setlocal tabstop=4 shiftwidth=4 softtabstop=4 expandtabs
 autocmd FileType cs setlocal tabstop=4 shiftwidth=4 softtabstop=4
 
 if fnamemodify(getcwd(), ':t') == 'braintree-java'

--- a/vimrc
+++ b/vimrc
@@ -79,7 +79,7 @@ augroup END
 " File Types
 
 autocmd FileType php setlocal tabstop=4 shiftwidth=4 softtabstop=4
-autocmd FileType python setlocal tabstop=4 shiftwidth=4 softtabstop=4 expandtabs
+autocmd FileType python setlocal tabstop=4 shiftwidth=4 softtabstop=4 expandtab
 autocmd FileType cs setlocal tabstop=4 shiftwidth=4 softtabstop=4
 
 if fnamemodify(getcwd(), ':t') == 'braintree-java'


### PR DESCRIPTION
# What

Sets expandtab for Python file types

# Why

When coding in Python, my natural tendency is to hit tab to indent, but without expandtabs enabled on Python file types, vim will enter a tab character rather than 4 spaces.  This can become maddening.

# Checklist

I don't _think_ this should require an RFC.
