### PR TITLE
Add plantuml syntax plugin

### DIFF
--- a/vimrc.bundles
+++ b/vimrc.bundles
@@ -9,6 +9,7 @@ else
 endif
 
 Plug 'akhaku/vim-java-unused-imports'
+Plug 'aklt/plantuml-syntax'
 Plug 'google/vim-maktaba'
 Plug 'google/vim-codefmt'
 Plug 'benmills/vim-commadown'


### PR DESCRIPTION
### What
Add plugin that supports plantuml files.

### Why
We use plantuml text files for drawing diagrams and it would be helpful to see the syntax color coded and formatted in vim. Additionally the plugin will cause the vim `:make` command to generate PNGs for the file.

# Checklist

- [ ] ~Send RFC email to Braintree developers _if change may be impactful_. Please include a link to this PR so that discussion about the pros and cons of the change remains linked to the proposed changes. **Recent examples include**: addition of linter and completer, no longer removing end-of-line whitespace on save, changing to fzf for file lookup.~
