### PR TITLE
Limit asyncomplete to Java files

### DIFF
--- a/vimrc.bundles
+++ b/vimrc.bundles
@@ -55,8 +55,8 @@ Plug 'pangloss/vim-javascript', { 'commit': 'ce0f529bbb938b42f757aeedbe8f5d95f09
 Plug 'mxw/vim-jsx'
 Plug 'pgr0ss/vim-github-url'
 Plug 'prabirshrestha/async.vim'
-Plug 'prabirshrestha/asyncomplete.vim'
-Plug 'prabirshrestha/asyncomplete-lsp.vim'
+Plug 'prabirshrestha/asyncomplete.vim', { 'for': 'java' }
+Plug 'prabirshrestha/asyncomplete-lsp.vim', { 'for': 'java' }
 Plug 'prabirshrestha/vim-lsp'
 Plug 'rust-lang/rust.vim'
 Plug 'scrooloose/nerdtree'


### PR DESCRIPTION
### What
Limit the asyncomplete plugin to Java files.

### Why
There's a bug in the plugin that's been reported in
prabirshrestha/asyncomplete.vim#27 that the plugin doesn't trigger
default autocomplete behavior when the plugin isn't serving any results.
This means in non-Java files the plugin causes no results to be
displayed instead of displaying symbols available in the buffer.

# Checklist

- [ ] ~Send RFC email to Braintree developers _if change may be impactful_. Please include a link to this PR so that discussion about the pros and cons of the change remains linked to the proposed changes. **Recent examples include**: addition of linter and completer, no longer removing end-of-line whitespace on save, changing to fzf for file lookup.~
