### PR TITLE
Remove textwidth override for txt files

### DIFF
--- a/vimrc
+++ b/vimrc
@@ -89,7 +89,6 @@ else
 endif
 
 autocmd FileType tex setlocal textwidth=78
-autocmd BufNewFile,BufRead *.txt setlocal textwidth=78
 
 autocmd FileType ruby runtime ruby_mappings.vim
 autocmd FileType python runtime python_mappings.vim


### PR DESCRIPTION
# What

This switches text files back to the default of `textwidth=0`.

# Why

`78` is very narrow and we don't have overrides for most other file types.

# Checklist

This doesn't seem worth an RFC to me. 

- ~~[ ] Send RFC email to Braintree developers _if change may be impactful_. Please include a link to this PR so that discussion about the pros and cons of the change remains linked to the proposed changes. **Recent examples include**: addition of linter and completer, no longer removing end-of-line whitespace on save, changing to fzf for file lookup.~~
