### PR TITLE
Use pytest as default python test runner, not nose

### DIFF
--- a/README.md
+++ b/README.md
@@ -83,7 +83,7 @@ Ruby Specific Mappings
 Python-Specific Mappings
 
 ```
-\rb - run all nosetests in the current buffer
-\rf - run the current nose test (requires nose-run-line-number)
+\rb - run all pytests in the current buffer
+\rf - run the current pytest
 \rl - run the last spec
 ```

--- a/README.md
+++ b/README.md
@@ -83,7 +83,7 @@ Ruby Specific Mappings
 Python-Specific Mappings
 
 ```
-\rb - run all pytests in the current buffer
-\rf - run the current pytest
-\rl - run the last spec
+\rb - run all tests in the current buffer (pytest or nose)
+\rf - run the current test
+\rl - run the last test
 ```

--- a/python_mappings.vim
+++ b/python_mappings.vim
@@ -1,2 +1,3 @@
 map <silent> <LocalLeader>rb :wa<CR> :TestFile<CR>
 map <silent> <LocalLeader>rf :wa<CR> :TestNearest<CR>
+map <silent> <LocalLeader>rl :wa<CR> :TestLast<CR>

--- a/vimrc
+++ b/vimrc
@@ -222,7 +222,7 @@ let g:go_highlight_trailing_whitespace_error = 0
 
 let test#strategy = "vimux"
 let test#custom_runners = {}
-let test#python#runner = 'nose'
+let test#python#runner = 'pytest'
 
 if filereadable(expand('WORKSPACE'))
   let test#custom_runners['java'] = ['bazeltest']

--- a/vimrc
+++ b/vimrc
@@ -223,6 +223,10 @@ let g:go_highlight_trailing_whitespace_error = 0
 let test#strategy = "vimux"
 let test#custom_runners = {}
 let test#python#runner = 'pytest'
+let nose_test = system('grep -q "nose" requirements.txt')
+if v:shell_error == 0
+  let test#python#runner = 'nose'
+endif
 
 if filereadable(expand('WORKSPACE'))
   let test#custom_runners['java'] = ['bazeltest']


### PR DESCRIPTION
# What
Updates `vim-test` config to use `pytest` as the default test runner, instead of `nose`.

Also, fixes `<leader>-rl` to re-run last test in python

# Why
As far as I can tell, `pytest` is much more widely used at Braintree than `nose`

# Checklist

- [x] Send RFC email to Braintree developers _if change may be impactful_. Please include a link to this PR so that discussion about the pros and cons of the change remains linked to the proposed changes. **Recent examples include**: addition of linter and completer, no longer removing end-of-line whitespace on save, changing to fzf for file lookup.
