### PR TITLE
Format python files with black on save (if black is used)

### DIFF
--- a/vimrc
+++ b/vimrc
@@ -161,6 +161,14 @@ if filereadable(expand(".rubocop.yml"))
   let g:ale_linters['ruby'] = ['rubocop']
 endif
 
+let g:ale_fixers = {}
+let g:ale_fix_on_save = 1
+
+let black = system('grep -q black Pipfile')
+if v:shell_error == 0
+  let g:ale_fixers['python'] = ['black']
+endif
+
 let html_use_css=1
 let html_number_lines=0
 let html_no_pre=1


### PR DESCRIPTION
Please use the following structure when proposing changes to our shared Vim configuration and make sure to complete the checklist at the end.

# What

If you use [black](https://github.com/python/black) and it's in the `Pipfile`, this will format python files on save.

# Why

Real time formatting is nice. We can't use black's vim plugin (https://github.com/python/black#vim) since our vim python is too old.

# Checklist

- ~~[ ] Send RFC email to Braintree developers _if change may be impactful_. Please include a link to this PR so that discussion about the pros and cons of the change remains linked to the proposed changes. **Recent examples include**: addition of linter and completer, no longer removing end-of-line whitespace on save, changing to fzf for file lookup.~~
