### PR TITLE
enable shfmt to auto format bash & sh files by default

### DIFF
--- a/vimrc
+++ b/vimrc
@@ -460,6 +460,36 @@ augroup autoformat_settings
   autocmd FileType bzl AutoFormatBuffer buildifier
 augroup END
 
+" Enable shfmt to automatically fix or format shell source code. This feature
+" can be disabled by touching .shfmt_disable in a repo's root directory.
+function s:EnableShfmt()
+  let l:cur_file_dir = expand('%:p:h')
+  if strlen(l:cur_file_dir) == 0
+    let l:git_dir = getcwd()
+  else
+    let l:git_dir = l:cur_file_dir
+  endif
+  let l:git_cmd = 'git -C ' . l:git_dir . ' rev-parse --show-toplevel 2>/dev/null'
+  let l:git_root = substitute(system(l:git_cmd), '\n\+$', '', '')
+  if v:shell_error == 0 && filereadable(l:git_root . '/.shfmt_disable')
+    augroup shells
+      autocmd!
+      autocmd FileType sh setlocal expandtab
+    augroup END
+    if has_key(g:ale_fixers, 'sh')
+      unlet g:ale_fixers.sh
+    endif
+  else
+    augroup shells
+      autocmd!
+      autocmd FileType sh setlocal noexpandtab
+    augroup END
+    let g:ale_fixers.sh = ['shfmt']
+  endif
+endfunction
+
+call s:EnableShfmt()
+
 "-------- Local Overrides
 ""If you have options you'd like to override locally for
 "some reason (don't want to store something in a


### PR DESCRIPTION
# What

Prior to this commit bash & sh files were not formatted automatically.
This commit formats those files on save with shfmt. The format can be
viewed here,
https://github.com/mvdan/sh/blob/master/syntax/canonical.sh. Notably
shfmt uses tabs by default rather than spaces. This commit also provides
the ability to disable the functionality per repo by touching
.shfmt_disable.

# Why
Manually formatting source code is tedious, error prone, and
inconsistent between people. Go has demonstrated that removing
formatting as a manual task provides more space for a person to
concentrate on program logic.

This functionality is enabled by default so that formatting is enforced
everywhere, but you can disable it if needed on a repo.

In my experience shfmt does a good job of formatting bash & sh files,
also the use of tabs comes with a couple of advantages:

1. Allows you to indent a heredoc with tabs, which improves the
readability of your code, e.g.

```
foo() {
	cat <<-EOF
		Heredocs are Great!
	EOF
}
```

2. Allows people to customize their visual tab width for better
readability.

# Checklist

- [x] Send RFC email to Braintree developers _if change may be
impactful_. Please include a link to this PR so that discussion about
the pros and cons of the change remains linked to the proposed changes.
**Recent examples include**: addition of linter and completer, no longer
removing end-of-line whitespace on save, changing to fzf for file
lookup.