### PR TITLE
enable shellcheck to lint bash & sh files

### DIFF
--- a/ftplugin/sh.vim
+++ b/ftplugin/sh.vim
@@ -1,0 +1,1 @@
+let g:ale_linters['sh'] = ['shellcheck']


### PR DESCRIPTION
# What

Prior to this commit we did not enable any linters for bash & sh. This
commit enables the shellcheck linter, https://www.shellcheck.net.

# Why

Using shellcheck when writing bash code has proven to be extremely
helpful. It outputs clear messages which are augmented by a very helpful
wiki. Each linter warning includes a specific code which makes it
extremely easy to google for, e.g. SC2086. The wiki pages also are a
great resource for learning about bash and understanding why the linter
flagged a particular construct, see the SC2086 wiki page as an example,
https://github.com/koalaman/shellcheck/wiki/SC2086. It has in my
experience one of the best workflows for linting code.

I discussed adding shellcheck to our dotfiles previously, but @pgr0ss
was rightfully concerned about all the noise for linting suggestions
like SC2086. Fortunately, version 0.7 of shellcheck supports autofixing
common errors like SC2086. It does this by outputting a diff format:

```
$ cat make-butter

file='butter & bubbles.md'
pandoc -f gfm -t html $file

$ shellcheck make-butter

In make-butter line 4:
pandoc -f gfm -t html $file
                      ^---^ SC2086: Double quote to prevent globbing and word splitting.

Did you mean:
pandoc -f gfm -t html "$file"

For more information:
  https://www.shellcheck.net/wiki/SC2086 -- Double quote to prevent globbing ...

$ shellcheck -i SC2086 -f diff make-butter

--- /home/jhathaway/make-butter
+++ /home/jhathaway/make-butter
@@ -1,4 +1,4 @@
 #!/bin/bash

 file='butter & bubbles.md'
-pandoc -f gfm -t html $file
+pandoc -f gfm -t html "$file"

```

This diff can that be applied with `git apply` and pull requested. With
this feature now present shellcheck is ready to be enabled by default.

# Checklist

- [x] Send RFC email to Braintree developers _if change may be
impactful_. Please include a link to this PR so that discussion about
the pros and cons of the change remains linked to the proposed changes.
**Recent examples include**: addition of linter and completer, no longer
removing end-of-line whitespace on save, changing to fzf for file
lookup.