### PR TITLE
Add shortcut for getting a GitHubURL

### DIFF
--- a/vimrc
+++ b/vimrc
@@ -289,6 +289,9 @@ map <silent> <C-p> :Files<CR>
 " Ack
 map <LocalLeader>aw :Ack '<C-R><C-W>'
 
+" GitHubURL
+map <silent> <LocalLeader>gh :GitHubURL<CR>
+
 " TComment
 map <silent> <LocalLeader>cc :TComment<CR>
 map <silent> <LocalLeader>uc :TComment<CR>


### PR DESCRIPTION
# What

Add a shortcut for getting a GItHub URL.

# Why

This could easily just live in folks `vimrc_local` but it seems like a pretty common workflow and I'd like to increase discoverability of this plugin because I think it's v useful. Luckily too there's not much contention for the `<Leader>gX` namespace. The only other function we have mapped there is `<Leader>gw` so I don't think this would be too confusing/disruptive. 

# Checklist

- [ ] Send RFC email to Braintree developers _if change may be impactful_. Please include a link to this PR so that discussion about the pros and cons of the change remains linked to the proposed changes. **Recent examples include**: addition of linter and completer, no longer removing end-of-line whitespace on save, changing to fzf for file lookup.
