### PR TITLE
Configure black to use pipenv

### DIFF
--- a/vimrc
+++ b/vimrc
@@ -167,6 +167,7 @@ let g:ale_fix_on_save = 1
 let black = system('grep -q black Pipfile')
 if v:shell_error == 0
   let g:ale_fixers['python'] = ['black']
+  let g:ale_python_black_auto_pipenv = 1
 endif
 
 let html_use_css=1


### PR DESCRIPTION
# What

Configure black to use pipenv.

# Why

Since we're already checking for a Pipfile, we can tell the plugin to
run Black via pipenv. This prevents having to also install Black outside
the virtualenv.

# Checklist

- ~~[ ] Send RFC email to Braintree developers _if change may be impactful_. Please include a link to this PR so that discussion about the pros and cons of the change remains linked to the proposed changes. **Recent examples include**: addition of linter and completer, no longer removing end-of-line whitespace on save, changing to fzf for file lookup.~~
