### PR TITLE
Fix terminal bell when loading vimrc

### DIFF
--- a/vimrc
+++ b/vimrc
@@ -133,7 +133,7 @@ let g:side_search_splitter = 'vnew'
 let g:side_search_split_pct = 0.4
 
 " SideSearch current word and return to original window
-nnoremap <Leader>ss :SideSearch <C-r><C-w><CR> | wincmd p
+nnoremap <Leader>ss :SideSearch <C-r><C-w><CR><C-w>p
 
 " SS shortcut and return to original window
  command! -complete=file -nargs=+ SS execute 'SideSearch <args>'


### PR DESCRIPTION
# What

For SideSearch macro, replace `| wincmd p ` with an equivalent key sequence.

# Why

There has been an issue with a terminal bell going off every time vim starts, due to the following line:
`nnoremap <Leader>ss :SideSearch <C-r><C-w><CR> | wincmd p`
The issue is that the pipe separates `wincmd` from `nnoremap` , not `:SideSearch`.  As a result `wincmd p` is run when the editing session is opened and the terminal beeps due to an error.  This is fixed by changing it to:
`nnoremap <Leader>ss :SideSearch <C-r><C-w><CR><C-w>p`
This results in the desired behavior as described by the comment on the line prior to where the macro is defined.

# Checklist

~~- [ ] Send RFC email to Braintree developers _if change may be impactful_. Please include a link to this PR so that discussion about the pros and cons of the change remains linked to the proposed changes. **Recent examples include**: addition of linter and completer, no longer removing end-of-line whitespace on save, changing to fzf for file lookup.~~
