### PR TITLE
Disable style highlighting, Enable gutter indicators instead

### DIFF
--- a/vimrc
+++ b/vimrc
@@ -140,8 +140,9 @@ vnoremap * :<C-u>call <SID>VSetSearch()<CR>/<CR>
 let g:ale_enabled = 1                     " Enable linting by default
 let g:ale_lint_on_text_changed = 'normal' " Only lint while in normal mode
 let g:ale_lint_on_insert_leave = 1        " Automatically lint when leaving insert mode
-let g:ale_set_signs = 0                   " Disable signs showing in the gutter to reduce interruptive visuals
+let g:ale_set_signs = 1                   " Enable signs showing in the gutter to reduce interruptive visuals
 let g:ale_linters_explicit = 1            " Only run linters that are explicitly listed below
+let g:ale_set_highlights = 0              " Disable highlighting as it interferes with readability and accessibility
 let g:ale_linters = {}
 let g:ale_linters['puppet'] = ['puppetlint']
 if filereadable(expand(".rubocop.yml"))


### PR DESCRIPTION
# What

Disable style highlighting, Enable gutter indicators instead

# Why

Current linting settings make it impossible to read certain lines of
code in ruby projects. Specifically the background highlighting for
syntax issues obscures symbols in ruby.

To be more cognizant of readability concerns moving this highlighting to
the gutter should satisfy our need to mark style issues while still
allowing for developers to read the code.

Previous Behavior:
![Previous](https://user-images.githubusercontent.com/141914/63620086-016ab180-c5b6-11e9-88b1-d951597b978c.png)
New Behavior:
![New](https://user-images.githubusercontent.com/141914/63620088-016ab180-c5b6-11e9-9a5d-3eea6825d761.png)



# Checklist

~- [ ] Send RFC email to Braintree developers _if change may be impactful_. Please include a link to this PR so that discussion about the pros and cons of the change remains linked to the proposed changes. **Recent examples include**: addition of linter and completer, no longer removing end-of-line whitespace on save, changing to fzf for file lookup.~
