### PR TITLE
Add shortcut for formatting the current document

### DIFF
--- a/vimrc
+++ b/vimrc
@@ -339,6 +339,9 @@ map <silent> <LocalLeader>ws /\s\+$<CR>
 
 map <silent> <LocalLeader>pp :set paste!<CR>
 
+" Format document
+map <silent> <LocalLeader>fd :LspDocumentFormat<CR>
+
 " YAML
 let g:vim_yaml_helper#auto_display_path = 1
 


### PR DESCRIPTION
# What

Add a shortcut for formatting the current document by invoking `:LspDocumentFormat`.

# Why

Formatting should be a fairly common operation, especially on Java codebases where this command is used to add missing imports. Adding a shortcut makes it much easier to invoke.

# Checklist

- [ ] Send RFC email to Braintree developers _if change may be impactful_. Please include a link to this PR so that discussion about the pros and cons of the change remains linked to the proposed changes. **Recent examples include**: addition of linter and completer, no longer removing end-of-line whitespace on save, changing to fzf for file lookup.
