### PR TITLE
Add ALE leader keys

### DIFF
--- a/vimrc
+++ b/vimrc
@@ -274,6 +274,15 @@ endif
 
 " ========= Shortcuts ========
 
+" ALE
+map <silent> <leader>an :ALENextWrap<CR>
+map <silent> <leader>ap :ALEPreviousWrap<CR>
+map <silent> <leader>aj :ALENextWrap<CR>
+map <silent> <leader>ak :ALEPreviousWrap<CR>
+map <silent> <leader>al :ALELint<CR>
+map <silent> <leader>af :ALEFix<CR>
+map <silent> <leader>ai :ALEInfo<CR>
+
 " NERDTree
 map <silent> <LocalLeader>nt :NERDTreeToggle<CR>
 map <silent> <LocalLeader>nr :NERDTree<CR>


### PR DESCRIPTION
# What

Add ALE leader keys
* cool af
* helps you lint (al) and fix (af)
* helps you debug (ai)
* helps you navigate (an/aj for next ap/ak for previous)

# Why

We heavily use leader keys and adding ALE leader keys would be very helpful.

# Checklist

- [X] Send RFC email to Braintree developers _if change may be impactful_. Please include a link to this PR so that discussion about the pros and cons of the change remains linked to the proposed changes. **Recent examples include**: addition of linter and completer, no longer removing end-of-line whitespace on save, changing to fzf for file lookup.
     - Since this is an addition, and not impactful to current workflows, this is probably not needed.
