### PR TITLE
Bump fzf plugins

### DIFF
--- a/vimrc.bundles
+++ b/vimrc.bundles
@@ -37,12 +37,12 @@ Plug 'jlanzarotta/bufexplorer', { 'commit': 'f3bbe12664b08038912faac586f6c0b5104
 Plug 'jparise/vim-graphql', { 'commit': '7ecedede603d16de5cca5ccefbde14d642b0d697' }
 Plug 'jtratner/vim-flavored-markdown'
 if expand('<sfile>') == '/etc/vim/vimrc.bundles'
-  Plug 'junegunn/fzf', { 'commit': 'ef80bd401fdab3979a72696dac585f1cbd463efc', 'dir': '/etc/vim/fzf', 'do': './install --bin' }
+  Plug 'junegunn/fzf', { 'tag': '0.19.0', 'dir': '/etc/vim/fzf', 'do': './install --bin' }
 
 else
-  Plug 'junegunn/fzf', { 'commit': 'ef80bd401fdab3979a72696dac585f1cbd463efc', 'dir': '~/.fzf', 'do': './install --bin' }
+  Plug 'junegunn/fzf', { 'tag': '0.19.0', 'dir': '~/.fzf', 'do': './install --bin' }
 endif
-Plug 'junegunn/fzf.vim', {'commit': '741d7caabf229ec183364413f8b6d077a9939838'}
+Plug 'junegunn/fzf.vim', {'commit': '65edb6ad99b51514aaf29afc25e35ce5f05281ba'}
 Plug 'kana/vim-textobj-user'
 Plug 'kchmck/vim-coffee-script'
 Plug 'kien/rainbow_parentheses.vim'

--- a/vimrc.bundles
+++ b/vimrc.bundles
@@ -37,9 +37,10 @@ Plug 'jlanzarotta/bufexplorer', { 'commit': 'f3bbe12664b08038912faac586f6c0b5104
 Plug 'jparise/vim-graphql', { 'commit': '7ecedede603d16de5cca5ccefbde14d642b0d697' }
 Plug 'jtratner/vim-flavored-markdown'
 if expand('<sfile>') == '/etc/vim/vimrc.bundles'
-  Plug 'junegunn/fzf', { 'tag': '0.16.7', 'dir': '/etc/vim/fzf', 'do': './install --bin' }
+  Plug 'junegunn/fzf', { 'commit': 'ef80bd401fdab3979a72696dac585f1cbd463efc', 'dir': '/etc/vim/fzf', 'do': './install --bin' }
+
 else
-  Plug 'junegunn/fzf', { 'tag': '0.16.7', 'dir': '~/.fzf', 'do': './install --bin' }
+  Plug 'junegunn/fzf', { 'commit': 'ef80bd401fdab3979a72696dac585f1cbd463efc', 'dir': '~/.fzf', 'do': './install --bin' }
 endif
 Plug 'junegunn/fzf.vim', {'commit': '741d7caabf229ec183364413f8b6d077a9939838'}
 Plug 'kana/vim-textobj-user'


### PR DESCRIPTION
# What

Bump the fzf and fzf.vim plugins.

# Why

The current combination of fzf and fzf.vim makes `:Tags` and
`<leader>ft` print an error instead of finding tags. Updating fzf
and fzf.vim to the latest makes it work.
