### PR TITLE
Organize ALE configurations by language and include ALEFix for ruby

### DIFF
--- a/ftplugin/elixir.vim
+++ b/ftplugin/elixir.vim
@@ -1,3 +1,5 @@
 map <silent> <LocalLeader>ra :wa<CR> :TestSuite<CR>
 map <silent> <LocalLeader>rb :wa<CR> :TestFile<CR>
 map <silent> <LocalLeader>rf :wa<CR> :TestNearest<CR>
+let b:ale_linters['elixir'] = ['mix']
+let g:ale_fixers['elixir'] = ['mix_format']

--- a/ftplugin/puppet.vim
+++ b/ftplugin/puppet.vim
@@ -1,0 +1,1 @@
+let g:ale_linters['puppet'] = ['puppetlint']

--- a/ftplugin/python.vim
+++ b/ftplugin/python.vim
@@ -1,0 +1,6 @@
+let black = system('grep -q black Pipfile')
+
+if v:shell_error == 0
+  let g:ale_fixers['python'] = ['black']
+  let g:ale_python_black_auto_pipenv = 1
+endif

--- a/ftplugin/ruby.vim
+++ b/ftplugin/ruby.vim
@@ -1,0 +1,4 @@
+if filereadable(expand(".rubocop.yml"))
+  let g:ale_linters['ruby'] = ['rubocop']
+  let g:ale_fixers['ruby'] = ['rubocop']
+endif

--- a/vimrc
+++ b/vimrc
@@ -146,20 +146,14 @@ let g:ale_set_signs = 1                   " Enable signs showing in the gutter t
 let g:ale_linters_explicit = 1            " Only run linters that are explicitly listed below
 let g:ale_set_highlights = 0              " Disable highlighting as it interferes with readability and accessibility
 let g:ale_linters = {}
-let g:ale_linters['puppet'] = ['puppetlint']
-let g:ale_linters['elixir'] = ['mix']
-if filereadable(expand(".rubocop.yml"))
-  let g:ale_linters['ruby'] = ['rubocop']
-endif
-
 let g:ale_fixers = {}
-let g:ale_fixers['elixir'] = ['mix_format']
-let g:ale_fix_on_save = 1
 
-let black = system('grep -q black Pipfile')
-if v:shell_error == 0
-  let g:ale_fixers['python'] = ['black']
-  let g:ale_python_black_auto_pipenv = 1
+if filereadable(expand(".ale_fix_on_save"))
+  " add an empty file named .ale_fix_on_save
+  " in any repository to enable ale fixers
+  " otherwise set the below line in your vimrc_local
+  " without the conditional
+  let g:ale_fix_on_save = 1
 endif
 
 let html_use_css=1
@@ -222,9 +216,9 @@ let g:sexp_enable_insert_mode_mappings = 0
 
 let g:puppet_align_hashes = 0
 
-let $FZF_DEFAULT_COMMAND = 'find . -name "*" -type f 2>/dev/null                                                         
+let $FZF_DEFAULT_COMMAND = 'find . -name "*" -type f 2>/dev/null
                             \ | grep -v -E "tmp\/|.gitmodules|.git\/|deps\/|_build\/|node_modules\/|vendor\/"
-                            \ | sed "s|^\./||"'                                                                          
+                            \ | sed "s|^\./||"'
 let $FZF_DEFAULT_OPTS = '--reverse'
 let g:fzf_tags_command = 'ctags -R --exclude=".git\|.svn\|log\|tmp\|db\|pkg" --extra=+f --langmap=Lisp:+.clj'
 let g:fzf_action = {


### PR DESCRIPTION
# What

Organize ALE configurations by language and include ALEFix for ruby

# Why

This sets a pattern for adding language specific configuration.  Also gives us `:ALEFix` now for ruby.

# How's it look?  Awesome

![ale_fixer](https://user-images.githubusercontent.com/5561166/75398254-f0289780-58ad-11ea-9435-865d988b1c3c.gif)


# Checklist

- [x] Send RFC email to Braintree developers _if change may be impactful_. Please include a link to this PR so that discussion about the pros and cons of the change remains linked to the proposed changes. **Recent examples include**: addition of linter and completer, no longer removing end-of-line whitespace on save, changing to fzf for file lookup.
