### PR TITLE
Add java-debug bundle to language server configuration

### DIFF
--- a/vimrc
+++ b/vimrc
@@ -258,10 +258,16 @@ autocmd FileType java autocmd BufWritePre * :UnusedImports
 
 " Language server for Java
 if executable('java-language-server')
+  let extensions = $HOME.'/language-servers/java/extensions'
+  let bundles = [
+        \ glob(extensions.'/debug/com.microsoft.java.debug.plugin/target/com.microsoft.java.debug.plugin-*.jar'),
+        \ ]
+
   autocmd User lsp_setup call lsp#register_server({
     \ 'name': 'java-language-server',
-    \ 'cmd': {server_info->['java-language-server', '--quiet']},
+    \ 'cmd': {server_info->['java-language-server']},
     \ 'whitelist': ['java'],
+    \ 'initialization_options': {'bundles': bundles },
     \ })
   autocmd FileType java nmap <buffer> <C-e> <plug>(lsp-document-diagnostics)
   autocmd FileType java nmap <buffer> <C-i> <plug>(lsp-hover)


### PR DESCRIPTION
# What

Update java language server initialization options to include the `java-debug` bundle.

# Why

To enable java debugging from vim.

# Checklist

- [ ] Send RFC email to Braintree developers _if change may be impactful_. Please include a link to this PR so that discussion about the pros and cons of the change remains linked to the proposed changes. **Recent examples include**: addition of linter and completer, no longer removing end-of-line whitespace on save, changing to fzf for file lookup.
