### PR TITLE
Add a ReverseLines command to reverse the lines in a file

### DIFF
--- a/vimrc
+++ b/vimrc
@@ -477,6 +477,8 @@ set tabline=%!MyTabLine()
 
 command! W w
 
+" https://vim.fandom.com/wiki/Reverse_order_of_lines
+command! -bar -range=% ReverseLines <line1>,<line2>g/^/m<line1>-1|nohl
 
 " Autoformat for bazel files
 augroup autoformat_settings


### PR DESCRIPTION
# What

Add a ReverseLines command to reverse the lines in a file. 

This works on the entire file and also a range of lines. Command from
the vim wiki: https://vim.fandom.com/wiki/Reverse_order_of_lines

# Why

I use the long form of this quite often. One example is when looking at sumo results which are ordered most recent first.

# Checklist

- ~~[ ] Send RFC email to Braintree developers _if change may be impactful_. Please include a link to this PR so that discussion about the pros and cons of the change remains linked to the proposed changes. **Recent examples include**: addition of linter and completer, no longer removing end-of-line whitespace on save, changing to fzf for file lookup.~~
