### PR TITLE
Remove pinned version from vim-javascript

### DIFF
--- a/vimrc.bundles
+++ b/vimrc.bundles
@@ -51,7 +51,7 @@ Plug 'markcornick/vim-bats'
 Plug 'mattn/emmet-vim'
 Plug 'mileszs/ack.vim'
 Plug 'nelstrom/vim-textobj-rubyblock'
-Plug 'pangloss/vim-javascript', { 'commit': 'ce0f529bbb938b42f757aeedbe8f5d95f095b51d' }
+Plug 'pangloss/vim-javascript'
 Plug 'mxw/vim-jsx'
 Plug 'pgr0ss/vim-github-url'
 Plug 'prabirshrestha/async.vim'


### PR DESCRIPTION
# What

Removes the outdated version pin for `vim-javascript`.

# Why

`vim-javascript` was pinned to a very old version. There must have been some breaking change back then, but now removing the pin doesn't break anything and gives us working highlighting with some newer JS features (notably optional chaining).

# Checklist

- ~Send RFC email to Braintree developers _if change may be impactful_. Please include a link to this PR so that discussion about the pros and cons of the change remains linked to the proposed changes. **Recent examples include**: addition of linter and completer, no longer removing end-of-line whitespace on save, changing to fzf for file lookup.~ change is not impactful, skipping