### PR TITLE
Include all rspec tests when printing specs from vim buffer

### DIFF
--- a/vimrc
+++ b/vimrc
@@ -326,7 +326,7 @@ map <silent> <LocalLeader>vx :wa<CR> :VimuxClosePanes<CR>
 map <silent> <LocalLeader>vp :VimuxPromptCommand<CR>
 vmap <silent> <LocalLeader>vs "vy :call VimuxRunCommand(@v)<CR>
 nmap <silent> <LocalLeader>vs vip<LocalLeader>vs<CR>
-map <silent> <LocalLeader>ds :call VimuxRunCommand('clear; grep -E "^ *describe[ \(]\|^ *context[ \(]\|^ *it[ \(]" ' . bufname("%"))<CR>
+map <silent> <LocalLeader>ds :call VimuxRunCommand('clear; grep -E "^ *describe[ \(]\|^ *context[ \(]\|^ *it[ \(]\|^ *specify[ \(]\|^ *example[ \(]" ' . bufname("%"))<CR>
 
 map <silent> <LocalLeader>rt :!ctags -R --exclude=".git\|.svn\|log\|tmp\|db\|pkg" --extra=+f --langmap=Lisp:+.clj<CR>
 


### PR DESCRIPTION
# What

`<Leader>ds` in a vim buffer with rspec tests will now print `'specify'` and `'example'` tests

# Why

This modifies a vim shortcut which prints all rspec tests/contexts/blocks in a vim buffer. It does not currently print tests written with the `specify` or `example` methods [documented here](https://rspec.info/documentation/3.9/rspec-core/#Aliases).

# Checklist

- [x] Send RFC email to Braintree developers _if change may be impactful_. Please include a link to this PR so that discussion about the pros and cons of the change remains linked to the proposed changes. **Recent examples include**: addition of linter and completer, no longer removing end-of-line whitespace on save, changing to fzf for file lookup.

Not applicable
