### PR TITLE
Add support for Rust Autocomplete

### DIFF
--- a/vimrc
+++ b/vimrc
@@ -238,6 +238,10 @@ let g:vim_markdown_folding_disabled = 1
 let g:go_fmt_command = "goimports"
 let g:go_highlight_trailing_whitespace_error = 0
 
+" Set Rust autocomplete trigger to control-space
+inoremap <C-@> <C-x><C-o>
+let g:racer_experimental_completer = 1
+
 let test#strategy = "vimux"
 let test#custom_runners = {}
 let test#python#runner = 'pytest'

--- a/vimrc.bundles
+++ b/vimrc.bundles
@@ -58,6 +58,7 @@ Plug 'prabirshrestha/async.vim'
 Plug 'prabirshrestha/asyncomplete.vim', { 'for': 'java' }
 Plug 'prabirshrestha/asyncomplete-lsp.vim', { 'for': 'java' }
 Plug 'prabirshrestha/vim-lsp'
+Plug 'racer-rust/vim-racer'
 Plug 'rust-lang/rust.vim'
 Plug 'scrooloose/nerdtree'
 Plug 'tfnico/vim-gradle'


### PR DESCRIPTION
Please use the following structure when proposing changes to our shared Vim configuration and make sure to complete the checklist at the end.

# What

Adds a plugin for rust complete support and maps Control-Space to initiate the autocomplete

# Why

Adding a feature! Our team uses Rust a lot and would like to see support improved