### PR TITLE
Modify sudo write command

### DIFF
--- a/vimrc
+++ b/vimrc
@@ -362,7 +362,7 @@ imap <C-L> <SPACE>=><SPACE>
 
 " ========= Functions ========
 
-command! SudoW w !sudo tee %
+command! SudoW w !sudo tee "%"
 
 " http://techspeak.plainlystated.com/2009/08/vim-tohtml-customization.html
 function! DivHtml(line1, line2)

--- a/vimrc
+++ b/vimrc
@@ -362,7 +362,7 @@ imap <C-L> <SPACE>=><SPACE>
 
 " ========= Functions ========
 
-command! SudoW w !sudo tee "%"
+command! SudoW w !sudo tee "%" > /dev/null
 
 " http://techspeak.plainlystated.com/2009/08/vim-tohtml-customization.html
 function! DivHtml(line1, line2)


### PR DESCRIPTION
# What / Why

The existing `SudoW` command provides an easy way to write a buffer if a file has accidentally been opened (and subsequently edited) with insufficient write permissions. This PR proposes some ergonomic tweaks.

* rename from `SudoW` to `W`; this is easier to remember (and type)
* quote the percent operator (which interpolates the filename) in case of spaces in the filename
* redirect `tee` output to `/dev/null` so that the buffer contents aren't re-printed
