### PR TITLE
Automatically format terraform *.tfvars files on save

### DIFF
--- a/ftplugin/terraform.vim
+++ b/ftplugin/terraform.vim
@@ -1,0 +1,2 @@
+let b:ale_fixers = ['terraform']
+let g:ale_fix_on_save = 1

--- a/vimrc
+++ b/vimrc
@@ -109,7 +109,7 @@ if version >= 700
 endif
 
 " Run terraform fmt on terraform files
-autocmd BufWritePre *.tf call terraform#fmt()
+autocmd BufWritePre *.tf,*.tfvars call terraform#fmt()
 
 " Status
 set laststatus=2

--- a/vimrc
+++ b/vimrc
@@ -108,9 +108,6 @@ if version >= 700
     autocmd FileType tex setlocal spell spelllang=en_us
 endif
 
-" Run terraform fmt on terraform files
-autocmd BufWritePre *.tf,*.tfvars call terraform#fmt()
-
 " Status
 set laststatus=2
 set statusline=


### PR DESCRIPTION
# What

Enable automatically formatting `*.tfvars` files when saving in vim.

# Why

This makes it easy to get the formatting of `*.tfvars` files to match that of `*.tf` files.