### PR TITLE
Install glaive for autoformat configurations

### DIFF
--- a/vimrc
+++ b/vimrc
@@ -482,11 +482,9 @@ command! -bar -range=% ReverseLines <line1>,<line2>g/^/m<line1>-1|nohl
 
 " Autoformat settings
 call glaive#Install()
-Glaive codefmt google_java_executable='java -jar google-java-format-1.7-all-deps.jar'
 
 augroup autoformat_settings
   autocmd FileType bzl AutoFormatBuffer buildifier
-  autocmd FileType java AutoFormatBuffer google-java-format
 augroup END
 
 "-------- Local Overrides

--- a/vimrc
+++ b/vimrc
@@ -480,9 +480,13 @@ command! W w
 " https://vim.fandom.com/wiki/Reverse_order_of_lines
 command! -bar -range=% ReverseLines <line1>,<line2>g/^/m<line1>-1|nohl
 
-" Autoformat for bazel files
+" Autoformat settings
+call glaive#Install()
+Glaive codefmt google_java_executable='java -jar google-java-format-1.7-all-deps.jar'
+
 augroup autoformat_settings
   autocmd FileType bzl AutoFormatBuffer buildifier
+  autocmd FileType java AutoFormatBuffer google-java-format
 augroup END
 
 "-------- Local Overrides

--- a/vimrc.bundles
+++ b/vimrc.bundles
@@ -11,6 +11,7 @@ endif
 Plug 'akhaku/vim-java-unused-imports'
 Plug 'aklt/plantuml-syntax'
 Plug 'google/vim-maktaba'
+Plug 'google/vim-glaive'
 Plug 'google/vim-codefmt'
 Plug 'benmills/vim-commadown'
 Plug 'benmills/vimux'


### PR DESCRIPTION
# What

Add the glaive plugin so that the autoformat plugin can be configured for other languages. See: https://github.com/google/vim-codefmt#configuring-formatters

# Why

So that we can push fewer commits that break in CI due to formatting issues.

# Checklist

- [ ] Send RFC email to Braintree developers _if change may be impactful_. Please include a link to this PR so that discussion about the pros and cons of the change remains linked to the proposed changes. **Recent examples include**: addition of linter and completer, no longer removing end-of-line whitespace on save, changing to fzf for file lookup.
