### PR TITLE
Add dotnet mappings

### DIFF
--- a/dotnet_mappings.vim
+++ b/dotnet_mappings.vim
@@ -1,4 +1,6 @@
 let g:test#csharp#dotnettest#options = '-f netcoreapp2.0'
+"let g:test#csharp#dotnettest#options = '-f netstandard1.3'
+"let g:test#csharp#dotnettest#options = '-f netcoreapp1.0'
 
 map <silent> <LocalLeader>rb :wa<CR> :TestFile<CR>
 map <silent> <LocalLeader>rf :wa<CR> :TestNearest<CR>

--- a/dotnet_mappings.vim
+++ b/dotnet_mappings.vim
@@ -1,0 +1,7 @@
+let g:test#csharp#dotnettest#options = '-f netcoreapp2.0'
+
+map <silent> <LocalLeader>rb :wa<CR> :TestFile<CR>
+map <silent> <LocalLeader>rf :wa<CR> :TestNearest<CR>
+map <silent> <LocalLeader>rl :wa<CR> :TestLast<CR>
+map <silent> <LocalLeader>rx :wa<CR> :VimuxCloseRunner<CR>
+map <silent> <LocalLeader>ri :wa<CR> :VimuxInspectRunner<CR>

--- a/vimrc
+++ b/vimrc
@@ -93,6 +93,7 @@ endif
 autocmd FileType tex setlocal textwidth=78
 
 autocmd FileType ruby runtime ruby_mappings.vim
+autocmd FileType cs runtime dotnet_mappings.vim
 autocmd FileType python runtime python_mappings.vim
 autocmd FileType java runtime java_mappings.vim
 


### PR DESCRIPTION
# What

Add dotnet mappings for vim.

# Why

This allows you to run tests from dotnet files.
