### PR TITLE
Add rust to list of languages for auto-stripping whitespace on save

### DIFF
--- a/vimrc
+++ b/vimrc
@@ -102,7 +102,7 @@ autocmd FileType java runtime java_mappings.vim
 let g:wstrip_highlight = 0
 " strip trailing whitespace on save for any lines modified for the following
 " languages
-autocmd FileType ruby,java,python,c,cpp,sql,puppet let b:wstrip_auto = 1
+autocmd FileType ruby,java,python,c,cpp,sql,puppet,rust let b:wstrip_auto = 1
 
 if version >= 700
     autocmd BufNewFile,BufRead *.txt setlocal spell spelllang=en_us


### PR DESCRIPTION
# What

Adds rust to the list of languages for stripping end-of-line whitespace on save.

# Why

Our team's development is heavy on rust.
