### PR TITLE
Remove java binding for C-e so it can be used to scroll

### DIFF
--- a/vimrc
+++ b/vimrc
@@ -264,7 +264,6 @@ if executable('java-language-server')
     \ 'cmd': {server_info->['java-language-server', '--quiet']},
     \ 'whitelist': ['java'],
     \ })
-  autocmd FileType java nmap <buffer> <C-e> <plug>(lsp-document-diagnostics)
   autocmd FileType java nmap <buffer> <C-i> <plug>(lsp-hover)
   autocmd FileType java nmap <buffer> <C-]> <plug>(lsp-definition)
   autocmd FileType java nmap <buffer> gr <plug>(lsp-references)


### PR DESCRIPTION
# What

Remove binding of `C-e` (`<CONTROL>` and `e`) to `lsp-document-diagnostics` for Java files.

# Why

The [default binding](http://vimdoc.sourceforge.net/htmldoc/scroll.html#CTRL-E) for `C-e` is to scroll the viewport one line at at a time.  I use this often when reading source code, however for Java files it is re-bound to a specific language server command. I currently work around this by manually making the change contained in this PR every time I create a new cpair. I'm sure this could be resolved within a `.vimrc_local` file, but I am not aware of folks using this particular language server binding, and I believe it's more likely an impediment to users used to the default binding.

# Checklist

- [ ] ~Send RFC email to Braintree developers _if change may be impactful_. Please include a link to this PR so that discussion about the pros and cons of the change remains linked to the proposed changes. **Recent examples include**: addition of linter and completer, no longer removing end-of-line whitespace on save, changing to fzf for file lookup.~

I will post a link to this PR to the #talk-java Slack channel, as this will reach the most likely affected users.
