### PR TITLE
Check for glaive before attempting to install

### DIFF
--- a/vimrc
+++ b/vimrc
@@ -474,9 +474,12 @@ command! W w
 " https://vim.fandom.com/wiki/Reverse_order_of_lines
 command! -bar -range=% ReverseLines <line1>,<line2>g/^/m<line1>-1|nohl
 
-" Autoformat settings
-call glaive#Install()
+" Initialize glaive if it's installed.
+if exists('*glaive#Install')
+  call glaive#Install()
+endif
 
+" Autoformat settings
 augroup autoformat_settings
   autocmd FileType bzl AutoFormatBuffer buildifier
 augroup END


### PR DESCRIPTION
# What

The PR https://github.com/braintreeps/vim_dotfiles/pull/159 causes errors when Vim is first loaded because it attempts to call `glaive#Install()` in the vimrc before the glaive plugin has been installed. This PR fixes it by only calling `glaive#Install()` if it exists.

# Why

To fix an error from appearing when vim is opened pre-`PlugInstall`.

# Checklist

- [ ] Send RFC email to Braintree developers _if change may be impactful_. Please include a link to this PR so that discussion about the pros and cons of the change remains linked to the proposed changes. **Recent examples include**: addition of linter and completer, no longer removing end-of-line whitespace on save, changing to fzf for file lookup.
