### PR TITLE
Add vim caser

### DIFF
--- a/vimrc.bundles
+++ b/vimrc.bundles
@@ -10,6 +10,7 @@ endif
 
 Plug 'akhaku/vim-java-unused-imports'
 Plug 'aklt/plantuml-syntax'
+Plug 'arthurxavierx/vim-caser'
 Plug 'google/vim-maktaba'
 Plug 'google/vim-glaive'
 Plug 'google/vim-codefmt'


### PR DESCRIPTION
# What

Add vim caser plugin

# Why

This plugin adds a series of shortcuts via `gs<char>` to change the case of a set of words per the documentation: https://github.com/arthurxavierx/vim-caser

# Checklist

This is not impactful as we are not aware of any keystrokes this would be clobbering and the functionality is helpful without being intrusive.