### PR TITLE
Add vim-sensible plugin

### DIFF
--- a/vimrc.bundles
+++ b/vimrc.bundles
@@ -80,6 +80,7 @@ Plug 'tpope/vim-rhubarb'
 Plug 'tpope/vim-surround'
 Plug 'tpope/vim-unimpaired'
 Plug 'tpope/vim-vinegar'
+Plug 'tpope/vim-sensible'
 Plug 'uarun/vim-protobuf'
 Plug 'vim-ruby/vim-ruby', { 'commit': '84565856e6965144e1c34105e03a7a7e87401acb' }
 Plug 'vim-scripts/Align'


### PR DESCRIPTION
# What

Add vim-sensible plugin from tpope.

# Why

We already use several tpope plugins and this one is intended to provide "sensible defaults that everyone can agree on." Who can disagree with that?
