### PR TITLE
Remap vim-unimpaired exchange-lines commands

### DIFF
--- a/vimrc
+++ b/vimrc
@@ -306,6 +306,14 @@ map <silent> <C-p> :Files<CR>
 " Ack
 map <LocalLeader>aw :Ack '<C-R><C-W>'
 
+
+" vim-unimpaired
+
+nmap <silent> <C-k> <Plug>unimpairedMoveUp
+nmap <silent> <C-j> <Plug>unimpairedMoveDown
+xmap <silent> <C-k> <Plug>unimpairedMoveSelectionUp<esc>gv
+xmap <silent> <C-j> <Plug>unimpairedMoveSelectionDown<esc>gv
+
 " GitHubURL
 map <silent> <LocalLeader>gh :GitHubURL<CR>
 


### PR DESCRIPTION
[![asciicast](https://asciinema.org/a/wQ5YIUEyN1uEiBPzGPZ1Ail8H.svg)](https://asciinema.org/a/wQ5YIUEyN1uEiBPzGPZ1Ail8H)

# What

Remaps vim-unimpaired key bindings for `[e` and `]e` to `<C-j>` and `<C-k>`

# Why

Vim unimpaired defines `[e` and `]e` to swap the line you are on with
the previous or next line. vim-ruby-block-helpers (also installed)
redefines `]e` to mean "RubyBlockEnd", overriding the existing `]e` for
ruby files.  This change remaps the vim-unimpaired bindings to <C-j> and
<C-k> so they no longer conflict. Additionally, it re-selects when
moving selections so that you can simply repeat the move to move things
around in a file.
