### PR TITLE
Add vim-gitgutter

### DIFF
--- a/vimrc.bundles
+++ b/vimrc.bundles
@@ -11,6 +11,8 @@ endif
 Plug 'akhaku/vim-java-unused-imports'
 Plug 'aklt/plantuml-syntax'
 Plug 'arthurxavierx/vim-caser'
+" Show git diff via Vim sign column.
+Plug 'airblade/vim-gitgutter'
 Plug 'google/vim-maktaba'
 Plug 'google/vim-glaive'
 Plug 'google/vim-codefmt'


### PR DESCRIPTION
[![asciicast](https://asciinema.org/a/4YjMLZpfhQyEjQmzkGISMEpWh.svg)](https://asciinema.org/a/4YjMLZpfhQyEjQmzkGISMEpWh)

# What

Add vim-gitgutter plugin.

# Why

- Provides visual feedback about the git diff in your vim gutter
- Allows you to jump between changes easily
