### PR TITLE
Add shortcut to search for tag

### DIFF
--- a/ruby_mappings.vim
+++ b/ruby_mappings.vim
@@ -22,6 +22,6 @@ map <silent> <LocalLeader>AS   :AS<CR>
 map <LocalLeader>rd Orequire "pry"; binding.pry<ESC>
 
 " Search for tag
-nmap <silent> gd :Tags '<C-R><C-W> <CR>
+nmap <silent> <LocalLeader>] :Tags '<C-R><C-W> <CR>
 
 setlocal isk+=?

--- a/ruby_mappings.vim
+++ b/ruby_mappings.vim
@@ -20,4 +20,8 @@ map <silent> <LocalLeader>AV   :AV<CR>
 map <silent> <LocalLeader>AS   :AS<CR>
 
 map <LocalLeader>rd Orequire "pry"; binding.pry<ESC>
+
+" Search for tag
+nmap <silent> gd :Tags '<C-R><C-W> <CR>
+
 setlocal isk+=?


### PR DESCRIPTION
# What

Add `gd` shortcut to search for a tag by name.

# Why

When multiple files use the same function names, it can be hard to navigate. Using `g<C-]>` to find a tag is not that easy to do.
