### PR TITLE
Remap ]h and [h to GitGutterNextHunk and GitGutterPrevHunk

### DIFF
--- a/vimrc
+++ b/vimrc
@@ -305,6 +305,8 @@ map <LocalLeader>aw :Ack '<C-R><C-W>'
 
 nmap <silent> <C-k> <Plug>unimpairedMoveUp
 nmap <silent> <C-j> <Plug>unimpairedMoveDown
+nmap <silent> ]h :GitGutterNextHunk<CR>
+nmap <silent> [h :GitGutterPrevHunk<CR>
 xmap <silent> <C-k> <Plug>unimpairedMoveSelectionUp<esc>gv
 xmap <silent> <C-j> <Plug>unimpairedMoveSelectionDown<esc>gv
 


### PR DESCRIPTION
# What

Remap `[h` and `]h` to GitGutterPrevHunk and GitGutterNextHunk.

# Why

We have a ruby block plugin that uses [c (which is the default binding
for GitGutterPrevHunk) so this was not working as it should.
