### PR TITLE
Remap ]c to ]C for RubyBlockSpecParentContext

### DIFF
--- a/ruby_mappings.vim
+++ b/ruby_mappings.vim
@@ -19,6 +19,10 @@ map <silent> <LocalLeader>AA   :A<CR>
 map <silent> <LocalLeader>AV   :AV<CR>
 map <silent> <LocalLeader>AS   :AS<CR>
 
+" Restore vim-diff shortcuts
+unmap ]c
+map <silent> ]C :RubyBlockSpecParentContext<CR>
+
 map <LocalLeader>rd Orequire "pry"; binding.pry<ESC>
 
 " Search for tag

--- a/vimrc
+++ b/vimrc
@@ -300,7 +300,6 @@ map <silent> <C-p> :Files<CR>
 " Ack
 map <LocalLeader>aw :Ack '<C-R><C-W>'
 
-
 " vim-unimpaired
 
 nmap <silent> <C-k> <Plug>unimpairedMoveUp


### PR DESCRIPTION
# What

Remap ]c to ]C for RubyBlockSpecParentContext

# Why

This shortcut conflicts with a builtin vim shortcut for vim-diff[1] so
it would be nice to change it to something unused.

[1]: http://vimdoc.sourceforge.net/htmldoc/diff.html#jumpto-diffs
