### PR TITLE
Add vim-abolish plugin

### DIFF
--- a/vimrc.bundles
+++ b/vimrc.bundles
@@ -82,6 +82,7 @@ Plug 'tpope/vim-rhubarb'
 Plug 'tpope/vim-surround'
 Plug 'tpope/vim-unimpaired'
 Plug 'tpope/vim-vinegar'
+Plug 'tpope/vim-abolish'
 Plug 'uarun/vim-protobuf'
 Plug 'vim-ruby/vim-ruby', { 'commit': '84565856e6965144e1c34105e03a7a7e87401acb' }
 Plug 'vim-scripts/Align'


### PR DESCRIPTION
[![asciicast](https://asciinema.org/a/42pjxlPvW6W7CfKYYHpOJXuiL.svg)](https://asciinema.org/a/42pjxlPvW6W7CfKYYHpOJXuiL)

# What

Add vim-abolish plugin.

# Why

Provides handy shortcuts for coercing names to
snake/camel/underscore-case.  Also adds handy case-sensitive substitution:

```
:%S/facilit{y,ies}/building{,s}/g
```
Will substitute facility for building, facilities for buildings, and it will preserve the casing of all matches.  For example, `Facility` would become `Building`, while `facility` would become `building`.
