### PR TITLE
Silently unmap ]c

### DIFF
--- a/ruby_mappings.vim
+++ b/ruby_mappings.vim
@@ -20,7 +20,7 @@ map <silent> <LocalLeader>AV   :AV<CR>
 map <silent> <LocalLeader>AS   :AS<CR>
 
 " Restore vim-diff shortcuts
-unmap ]c
+silent! unmap ]c
 map <silent> ]C :RubyBlockSpecParentContext<CR>
 
 map <LocalLeader>rd Orequire "pry"; binding.pry<ESC>


### PR DESCRIPTION

# What

Silently unmap ]c

# Why

Prevents an error message that happens when you open a second ruby file since the keybinding is already unmapped.