### PR TITLE
Add splitjoin plugin

### DIFF
--- a/vimrc.bundles
+++ b/vimrc.bundles
@@ -92,6 +92,7 @@ Plug 'vim-scripts/matchit.zip'
 Plug 'rodjek/vim-puppet'
 Plug 'tweekmonster/wstrip.vim', { 'commit': '02826534e60a492b58f9515f5b8225d86f74fbc8' }
 Plug 'leafgarland/typescript-vim'
+Plug 'AndrewRadev/splitjoin.vim'
 
 if v:version >= 800 || has('nvim')
   Plug 'w0rp/ale'


### PR DESCRIPTION
[![asciicast](https://asciinema.org/a/SWi7zdod0LGfeG3RxneFtUJXY.svg)](https://asciinema.org/a/SWi7zdod0LGfeG3RxneFtUJXY)

# What

Add [splitjoin](https://github.com/AndrewRadev/splitjoin.vim) plugin.

# Why

- Makes it easy to swap block styles (do/end vs {})

# Keys

- `gS` to split (i.e. `{}` -> `do;end`)
- `gJ` to join (i.e. `do;end` -> `{}`)
