### PR TITLE
Add vim-swap plugin

### DIFF
--- a/vimrc.bundles
+++ b/vimrc.bundles
@@ -92,6 +92,7 @@ Plug 'vim-scripts/matchit.zip'
 Plug 'rodjek/vim-puppet'
 Plug 'tweekmonster/wstrip.vim', { 'commit': '02826534e60a492b58f9515f5b8225d86f74fbc8' }
 Plug 'leafgarland/typescript-vim'
+Plug 'machakann/vim-swap'
 
 if v:version >= 800 || has('nvim')
   Plug 'w0rp/ale'


### PR DESCRIPTION
[![asciicast](https://asciinema.org/a/96lK1QgImmQ7GDtrwtdPpaxoF.svg)](https://asciinema.org/a/96lK1QgImmQ7GDtrwtdPpaxoF)

# What

Add [vim-swap](https://github.com/machakann/vim-swap) plugin.

# Why

Makes it easy to swap items in an ordered list.

# Keys

g<

g< swaps the item under the cursor with the former item. Moving cursor on the arg2 and pressing g<, then it swaps arg2 and the former one, arg1, to get:

call foo(arg2, arg1, arg3)

g>

g> swaps the item under the cursor with the latter item. Moving cursor on the arg2 and pressing g>, then it swaps arg2 and the latter one, arg3, to get:

call foo(arg1, arg3, arg2)

gs

gs works more interactive. It starts "swap mode", as if there was the sub-mode of vim editor. In the mode, use h/l to swap items, j/k to choose item, numbers 1 ~ 9 to select nth item, u/<C-r> to undo/redo, g/G to group/ungroup items, s/S to sort, r to reverse, and as you know <Esc> to exit "swap mode". gs function can be used also in visual mode. In linewise-visual and blockwise-visual mode, this plugin always swaps in each line. For example, assume that the three lines were in a buffer:
