### PR TITLE
Add vim-qf plugin

### DIFF
--- a/vimrc.bundles
+++ b/vimrc.bundles
@@ -92,6 +92,7 @@ Plug 'vim-scripts/matchit.zip'
 Plug 'rodjek/vim-puppet'
 Plug 'tweekmonster/wstrip.vim', { 'commit': '02826534e60a492b58f9515f5b8225d86f74fbc8' }
 Plug 'leafgarland/typescript-vim'
+Plug 'romainl/vim-qf'
 
 if v:version >= 800 || has('nvim')
   Plug 'w0rp/ale'


### PR DESCRIPTION
[![asciicast](https://asciinema.org/a/kBbTV1q4QDoYNLDwwXjEEKCWK.svg)](https://asciinema.org/a/kBbTV1q4QDoYNLDwwXjEEKCWK)

# What

Add [vim-qf](https://github.com/romainl/vim-qf) plugin.

# Why

- Helps with managing the quickfix list

# Keys
None that I'm aware of, but on the github page it shows a demo video suggesting that `<M-)>` works to go to the next filegroup in the quickfix list.