### PR TITLE
Enable LSP diagnostic echo

### DIFF
--- a/vimrc
+++ b/vimrc
@@ -245,6 +245,7 @@ endif
 
 let g:lsp_log_verbose = 1
 let g:lsp_log_file = '/tmp/vim-lsp.log'
+let g:lsp_diagnostics_echo_cursor = 1
 let g:asyncomplete_auto_popup = 0
 
 " Define settings and shortcuts for language server-enabled buffers.


### PR DESCRIPTION
This PR simply enables LSP diagnostic echoing, which shows the error at the bottom of the window when the cursor hovers over one. Without this, it is unclear what the problem is.