### PR TITLE
Remove vim-lsp log lines by default

### DIFF
--- a/vimrc
+++ b/vimrc
@@ -243,8 +243,6 @@ if filereadable(expand('WORKSPACE'))
   let g:test#java#bazeltest#file_pattern = '.*/test/.*\.java$'
 endif
 
-let g:lsp_log_verbose = 1
-let g:lsp_log_file = '/tmp/vim-lsp.log'
 let g:lsp_diagnostics_echo_cursor = 1
 let g:asyncomplete_auto_popup = 0
 


### PR DESCRIPTION
Apparently the log configuration for `vim-lsp` causes issues for some people ([link](https://github.com/braintreeps/vim_dotfiles/pull/179#issuecomment-732252196)), so this PR removes those two lines because they're not really needed by default.