### PR TITLE
Update default dotnet framework version

### DIFF
--- a/dotnet_mappings.vim
+++ b/dotnet_mappings.vim
@@ -1,4 +1,4 @@
-let g:test#csharp#dotnettest#options = '-f netcoreapp2.0'
+let g:test#csharp#dotnettest#options = '-f netcoreapp3.1'
 "let g:test#csharp#dotnettest#options = '-f netstandard1.3'
 "let g:test#csharp#dotnettest#options = '-f netcoreapp1.0'
 


### PR DESCRIPTION
# What

Update the default dotnet framework version.

# Why

This is required to run tests against the current SDK version.
