### PR TITLE
Add javascript vim-test mappings

### DIFF
--- a/javascript_mappings.vim
+++ b/javascript_mappings.vim
@@ -1,5 +1,3 @@
-let g:test#javascript#mocha#file_pattern = '.*_spec.js'
-
 map <silent> <LocalLeader>rb :wa<CR> :TestFile<CR>
 map <silent> <LocalLeader>rf :wa<CR> :TestNearest<CR>
 map <silent> <LocalLeader>rl :wa<CR> :TestLast<CR>

--- a/javascript_mappings.vim
+++ b/javascript_mappings.vim
@@ -1,0 +1,7 @@
+let g:test#javascript#mocha#file_pattern = '.*_spec.js'
+
+map <silent> <LocalLeader>rb :wa<CR> :TestFile<CR>
+map <silent> <LocalLeader>rf :wa<CR> :TestNearest<CR>
+map <silent> <LocalLeader>rl :wa<CR> :TestLast<CR>
+map <silent> <LocalLeader>rx :wa<CR> :VimuxCloseRunner<CR>
+map <silent> <LocalLeader>ri :wa<CR> :VimuxInspectRunner<CR>

--- a/vimrc
+++ b/vimrc
@@ -94,6 +94,7 @@ autocmd FileType tex setlocal textwidth=78
 
 autocmd FileType ruby runtime ruby_mappings.vim
 autocmd FileType cs runtime dotnet_mappings.vim
+autocmd FileType javascript runtime javascript_mappings.vim
 autocmd FileType python runtime python_mappings.vim
 autocmd FileType java runtime java_mappings.vim
 


### PR DESCRIPTION
# What

This enables running mocha tests in the node SDK (requires a small
change to the SDK as well).

# Why

It is convenient to be able to run tests with `\rf`.
