### PR TITLE
Remove extraneous `space` character from compound/multi-line mappings to avoid side-effects.

### DIFF
--- a/dotnet_mappings.vim
+++ b/dotnet_mappings.vim
@@ -2,8 +2,8 @@ let g:test#csharp#dotnettest#options = '-f netcoreapp3.1'
 "let g:test#csharp#dotnettest#options = '-f netstandard1.3'
 "let g:test#csharp#dotnettest#options = '-f netcoreapp1.0'
 
-map <silent> <LocalLeader>rb :wa<CR> :TestFile<CR>
-map <silent> <LocalLeader>rf :wa<CR> :TestNearest<CR>
-map <silent> <LocalLeader>rl :wa<CR> :TestLast<CR>
-map <silent> <LocalLeader>rx :wa<CR> :VimuxCloseRunner<CR>
-map <silent> <LocalLeader>ri :wa<CR> :VimuxInspectRunner<CR>
+map <silent> <LocalLeader>rb :wa<CR>:TestFile<CR>
+map <silent> <LocalLeader>rf :wa<CR>:TestNearest<CR>
+map <silent> <LocalLeader>rl :wa<CR>:TestLast<CR>
+map <silent> <LocalLeader>rx :wa<CR>:VimuxCloseRunner<CR>
+map <silent> <LocalLeader>ri :wa<CR>:VimuxInspectRunner<CR>

--- a/ftplugin/elixir.vim
+++ b/ftplugin/elixir.vim
@@ -1,5 +1,5 @@
-map <silent> <LocalLeader>ra :wa<CR> :TestSuite<CR>
-map <silent> <LocalLeader>rb :wa<CR> :TestFile<CR>
-map <silent> <LocalLeader>rf :wa<CR> :TestNearest<CR>
+map <silent> <LocalLeader>ra :wa<CR>:TestSuite<CR>
+map <silent> <LocalLeader>rb :wa<CR>:TestFile<CR>
+map <silent> <LocalLeader>rf :wa<CR>:TestNearest<CR>
 let b:ale_linters['elixir'] = ['mix']
 let g:ale_fixers['elixir'] = ['mix_format']

--- a/java_mappings.vim
+++ b/java_mappings.vim
@@ -1,4 +1,4 @@
-map <silent> <LocalLeader>rs :wa<CR> :TestSuite<CR>
-map <silent> <LocalLeader>rb :wa<CR> :TestFile<CR>
-map <silent> <LocalLeader>rf :wa<CR> :TestNearest<CR>
-map <silent> <LocalLeader>rl :wa<CR> :TestLast<CR>
+map <silent> <LocalLeader>rs :wa<CR>:TestSuite<CR>
+map <silent> <LocalLeader>rb :wa<CR>:TestFile<CR>
+map <silent> <LocalLeader>rf :wa<CR>:TestNearest<CR>
+map <silent> <LocalLeader>rl :wa<CR>:TestLast<CR>

--- a/javascript_mappings.vim
+++ b/javascript_mappings.vim
@@ -1,5 +1,5 @@
-map <silent> <LocalLeader>rb :wa<CR> :TestFile<CR>
-map <silent> <LocalLeader>rf :wa<CR> :TestNearest<CR>
-map <silent> <LocalLeader>rl :wa<CR> :TestLast<CR>
-map <silent> <LocalLeader>rx :wa<CR> :VimuxCloseRunner<CR>
-map <silent> <LocalLeader>ri :wa<CR> :VimuxInspectRunner<CR>
+map <silent> <LocalLeader>rb :wa<CR>:TestFile<CR>
+map <silent> <LocalLeader>rf :wa<CR>:TestNearest<CR>
+map <silent> <LocalLeader>rl :wa<CR>:TestLast<CR>
+map <silent> <LocalLeader>rx :wa<CR>:VimuxCloseRunner<CR>
+map <silent> <LocalLeader>ri :wa<CR>:VimuxInspectRunner<CR>

--- a/python_mappings.vim
+++ b/python_mappings.vim
@@ -1,3 +1,3 @@
-map <silent> <LocalLeader>rb :wa<CR> :TestFile<CR>
-map <silent> <LocalLeader>rf :wa<CR> :TestNearest<CR>
-map <silent> <LocalLeader>rl :wa<CR> :TestLast<CR>
+map <silent> <LocalLeader>rb :wa<CR>:TestFile<CR>
+map <silent> <LocalLeader>rf :wa<CR>:TestNearest<CR>
+map <silent> <LocalLeader>rl :wa<CR>:TestLast<CR>

--- a/ruby_mappings.vim
+++ b/ruby_mappings.vim
@@ -9,11 +9,11 @@ endfunction
 command! TestContext :call TestContext()
 
 map <silent> <LocalLeader>rc :TestContext<CR>
-map <silent> <LocalLeader>rb :wa<CR> :TestFile<CR>
-map <silent> <LocalLeader>rf :wa<CR> :TestNearest<CR>
-map <silent> <LocalLeader>rl :wa<CR> :TestLast<CR>
-map <silent> <LocalLeader>rx :wa<CR> :VimuxCloseRunner<CR>
-map <silent> <LocalLeader>ri :wa<CR> :VimuxInspectRunner<CR>
+map <silent> <LocalLeader>rb :wa<CR>:TestFile<CR>
+map <silent> <LocalLeader>rf :wa<CR>:TestNearest<CR>
+map <silent> <LocalLeader>rl :wa<CR>:TestLast<CR>
+map <silent> <LocalLeader>rx :wa<CR>:VimuxCloseRunner<CR>
+map <silent> <LocalLeader>ri :wa<CR>:VimuxInspectRunner<CR>
 map <silent> <LocalLeader>rs :!ruby -c %<CR>
 map <silent> <LocalLeader>AA   :A<CR>
 map <silent> <LocalLeader>AV   :AV<CR>

--- a/vimrc
+++ b/vimrc
@@ -359,10 +359,10 @@ map <silent> <LocalLeader>cc :TComment<CR>
 map <silent> <LocalLeader>uc :TComment<CR>
 
 " Vimux
-map <silent> <LocalLeader>vl :wa<CR> :VimuxRunLastCommand<CR>
-map <silent> <LocalLeader>vi :wa<CR> :VimuxInspectRunner<CR>
-map <silent> <LocalLeader>vk :wa<CR> :VimuxInterruptRunner<CR>
-map <silent> <LocalLeader>vx :wa<CR> :VimuxClosePanes<CR>
+map <silent> <LocalLeader>vl :wa<CR>:VimuxRunLastCommand<CR>
+map <silent> <LocalLeader>vi :wa<CR>:VimuxInspectRunner<CR>
+map <silent> <LocalLeader>vk :wa<CR>:VimuxInterruptRunner<CR>
+map <silent> <LocalLeader>vx :wa<CR>:VimuxClosePanes<CR>
 map <silent> <LocalLeader>vp :VimuxPromptCommand<CR>
 vmap <silent> <LocalLeader>vs "vy :call VimuxRunCommand(@v)<CR>
 nmap <silent> <LocalLeader>vs vip<LocalLeader>vs<CR>


### PR DESCRIPTION
# What

Remove extraneous `space` character from compound/multi-line mappings to avoid side-effects.

# Why

Invoking a mapping (eg: `\rf`) includes a `space` between the `:wa<CR>` and `:TestNearest<CR>`.

For those who do not remap the `space` key, this simply moves the cursor one character to the right; this may not be a huge deal, but it's also not expected.

For those who do remap the `space` key, it activates that mapping which is not desirable.

# Checklist

I have not sent an RFC email as I don't think this is an impactful change, but I am open to doing so if people think otherwise.