### PR TITLE
Add vim-signature plugin

### DIFF
--- a/vimrc.bundles
+++ b/vimrc.bundles
@@ -40,6 +40,7 @@ Plug 'hashivim/vim-terraform'
 Plug 'jlanzarotta/bufexplorer', { 'commit': 'f3bbe12664b08038912faac586f6c0b5104325c3' }
 Plug 'jparise/vim-graphql', { 'commit': '7ecedede603d16de5cca5ccefbde14d642b0d697' }
 Plug 'jtratner/vim-flavored-markdown'
+Plug 'kshenoy/vim-signature'
 if expand('<sfile>') == '/etc/vim/vimrc.bundles'
   Plug 'junegunn/fzf', { 'tag': '0.19.0', 'dir': '/etc/vim/fzf', 'do': './install --bin' }
 


### PR DESCRIPTION
# What

Add vim-signature plugin.

# Why

It makes marks visible in the gutter, which makes it easier to use them
for navigation.

![Screen Shot 2021-01-04 at 8 22 02 PM](https://user-images.githubusercontent.com/1313844/103606303-e5c22b80-4eca-11eb-91eb-e63aa4ecd2b5.png)

It does not conflict with other plugins that use the gutter (see screenshot -- you can still see git diffs in the gutter, for example.)