### PR TITLE
Golang Shortcuts & Language Server

### DIFF
--- a/ftplugin/go.vim
+++ b/ftplugin/go.vim
@@ -1,0 +1,4 @@
+map <silent> <LocalLeader>ra :wa<CR> :TestSuite<CR>
+map <silent> <LocalLeader>rb :wa<CR> :TestFile<CR>
+map <silent> <LocalLeader>rf :wa<CR> :TestNearest<CR>
+map <silent> <LocalLeader>rl :wa<CR> :TestLast<CR>

--- a/vimrc
+++ b/vimrc
@@ -276,6 +276,22 @@ augroup lsp_install
   autocmd User lsp_buffer_enabled call s:on_lsp_buffer_enabled()
 augroup END
 
+if executable('gopls')
+  function! s:register_lsp_golang()
+    if exists('*lsp#register_command')
+      call lsp#register_server({
+            \ 'name': 'go-lang',
+            \ 'cmd': {server_info->['gopls']},
+            \ 'allowlist': ['go'],
+            \ })
+    else
+      echoerr 'Function lsp#register_command() not found, please update your vim-lsp installation'
+    endif
+  endfunction
+
+  autocmd User lsp_setup call s:register_lsp_golang()
+endif
+
 " Remove unused imports for Java
 autocmd FileType java autocmd BufWritePre * :UnusedImports
 

--- a/vimrc.bundles
+++ b/vimrc.bundles
@@ -26,7 +26,6 @@ Plug 'ekalinin/Dockerfile.vim'
 Plug 'elixir-lang/vim-elixir'
 Plug 'elubow/cql-vim'
 Plug 'fatih/vim-go', { 'do': ':GoInstallBinaries' }
-Plug 'maralla/completor.vim', { 'for': 'go' }
 Plug 'Glench/Vim-Jinja2-Syntax'
 Plug 'godlygeek/tabular' | Plug 'plasticboy/vim-markdown'
 Plug 'google/vim-jsonnet'


### PR DESCRIPTION
# What

1. Shortcuts for golang tests.
2. Removing `maralla/completor.vim`
3. Registering the golang language server.

# Why

1. `\rf` is a lot faster than switching panes and typing `go test -run 'TestMyFunction' `
2. This plugin has been causing some kind of panic, and inserting it as the only result in completion drop-downs: 
![Screen Shot 2021-01-15 at 12 58 53 PM](https://user-images.githubusercontent.com/71199/104775019-465c2e80-573d-11eb-923f-a6d128369b36.png)
  I was unable to get it into a working state. Using `vim-go` gives us helpful auto-completion via `<C-x><C-o>`
3. This gives us a lot of nice features, including all of the same shortcuts we already use for Java (rename, jump to definition/implementation, find references, etc.): https://github.com/braintreeps/vim_dotfiles/blob/8b67b36cfaa74ca9c3974364caea507a11e5d55c/vimrc#L255-L270