### PR TITLE
Add vim-crystal plugin to support Crystal lang

### DIFF
--- a/vimrc.bundles
+++ b/vimrc.bundles
@@ -84,6 +84,7 @@ Plug 'tpope/vim-unimpaired'
 Plug 'tpope/vim-vinegar'
 Plug 'tpope/vim-abolish'
 Plug 'uarun/vim-protobuf'
+Plug 'vim-crystal/vim-crystal'
 Plug 'vim-ruby/vim-ruby', { 'commit': '84565856e6965144e1c34105e03a7a7e87401acb' }
 Plug 'vim-scripts/Align'
 Plug 'vim-scripts/VimClojure'


### PR DESCRIPTION
# What

Add [`vim-crystal` plugin](https://github.com/vim-crystal/vim-crystal)

# Why

To add support for Crystal language files.

# Checklist

- [ ] Send RFC email to Braintree developers _if change may be impactful_. Please include a link to this PR so that discussion about the pros and cons of the change remains linked to the proposed changes. **Recent examples include**: addition of linter and completer, no longer removing end-of-line whitespace on save, changing to fzf for file lookup.
