### PR TITLE
Fix command for run last vimux in README

### DIFF
--- a/README.md
+++ b/README.md
@@ -48,7 +48,7 @@ Vimux (must be inside a tmux)
 ```
 \vp - prompt for a command to run in vimux
 \vs - send the block of code to the vimux window
-\rl - run the last command
+\vl - run the last vimux command
 ```
 
 Jump to definition - CTags


### PR DESCRIPTION
# What

Fix the shortcut for running the last vimux command to `\vl`

# Why

It currently shows the command to run the last test, not vimux command.

# Checklist

- [ ] Send RFC email to Braintree developers _if change may be impactful_. Please include a link to this PR so that discussion about the pros and cons of the change remains linked to the proposed changes. **Recent examples include**: addition of linter and completer, no longer removing end-of-line whitespace on save, changing to fzf for file lookup.
