### PR TITLE
Add support for Neovim-native LSP

### DIFF
--- a/config/nvim/init.vim
+++ b/config/nvim/init.vim
@@ -1,3 +1,94 @@
     set runtimepath^=~/.vim runtimepath+=~/.vim/after
     let &packpath = &runtimepath
     source ~/.vim/vimrc
+
+if has('nvim-0.5')
+  lua << EOF
+  local status, nvim_lsp = pcall(require, 'lspconfig')
+  if status then
+    local on_attach = function(client, bufnr)
+      local function buf_set_keymap(...) vim.api.nvim_buf_set_keymap(bufnr, ...) end
+      local function buf_set_option(...) vim.api.nvim_buf_set_option(bufnr, ...) end
+
+      buf_set_option('omnifunc', 'v:lua.vim.lsp.omnifunc')
+
+      -- Mappings.
+      local opts = { noremap=true, silent=true }
+
+      -- Inspired by https://github.com/neovim/nvim-lspconfig/#keybindings-and-completion,
+      -- but with <leader> instead of <space>
+
+      -- Navigation
+      buf_set_keymap('n', 'gD', '<Cmd>lua vim.lsp.buf.declaration()<CR>', opts)
+      buf_set_keymap('n', 'gd', '<Cmd>lua vim.lsp.buf.definition()<CR>', opts)
+      buf_set_keymap('n', '<Leader>D', '<cmd>lua vim.lsp.buf.type_definition()<CR>', opts)
+
+      -- Information
+      buf_set_keymap('n', 'K', '<Cmd>lua vim.lsp.buf.hover()<CR>', opts)
+      buf_set_keymap('n', 'gi', '<cmd>lua vim.lsp.buf.implementation()<CR>', opts)
+      buf_set_keymap('n', '<C-k>', '<cmd>lua vim.lsp.buf.signature_help()<CR>', opts)
+      buf_set_keymap('n', 'gr', '<cmd>lua vim.lsp.buf.references()<CR>', opts)
+      buf_set_keymap('n', '<Leader>ds', '<cmd>lua vim.lsp.buf.document_symbol()<CR>', opts)
+
+      -- Diagnostics
+      buf_set_keymap('n', '[d', '<cmd>lua vim.lsp.diagnostic.goto_prev()<CR>', opts)
+      buf_set_keymap('n', ']d', '<cmd>lua vim.lsp.diagnostic.goto_next()<CR>', opts)
+      buf_set_keymap('n', '<Leader>e', '<cmd>lua vim.lsp.diagnostic.show_line_diagnostics()<CR>', opts)
+      buf_set_keymap('n', '<Leader>q', '<cmd>lua vim.lsp.diagnostic.set_loclist()<CR>', opts)
+
+      -- Refactoring
+      buf_set_keymap('n', '<Leader>rn', '<cmd>lua vim.lsp.buf.rename()<CR>', opts)
+      buf_set_keymap('n', '<Leader>ca', '<cmd>lua vim.lsp.buf.code_action()<CR>', opts)
+
+      -- Workspaces
+      buf_set_keymap('n', '<Leader>wa', '<cmd>lua vim.lsp.buf.add_workspace_folder()<CR>', opts)
+      buf_set_keymap('n', '<Leader>wr', '<cmd>lua vim.lsp.buf.remove_workspace_folder()<CR>', opts)
+      buf_set_keymap('n', '<Leader>wl', '<cmd>lua print(vim.inspect(vim.lsp.buf.list_workspace_folders()))<CR>', opts)
+      buf_set_keymap('n', '<Leader>ws', '<cmd>lua vim.lsp.buf.workspace_symbol()<CR>', opts)
+
+      -- Set some keybinds conditional on server capabilities
+      if client.resolved_capabilities.document_formatting then
+        buf_set_keymap("n", "<Leader>fd", "<cmd>lua vim.lsp.buf.formatting()<CR>", opts)
+      elseif client.resolved_capabilities.document_range_formatting then
+        buf_set_keymap("n", "<Leader>fd", "<cmd>lua vim.lsp.buf.formatting()<CR>", opts)
+      end
+
+      -- Set autocommands conditional on server_capabilities
+      if client.resolved_capabilities.document_highlight then
+        vim.api.nvim_exec([[
+          hi LspReferenceRead cterm=bold ctermbg=red guibg=LightYellow
+          hi LspReferenceText cterm=bold ctermbg=red guibg=LightYellow
+          hi LspReferenceWrite cterm=bold ctermbg=red guibg=LightYellow
+          augroup lsp_document_highlight
+            autocmd!
+            autocmd CursorHold <buffer> lua vim.lsp.buf.document_highlight()
+            autocmd CursorMoved <buffer> lua vim.lsp.buf.clear_references()
+          augroup END
+        ]], false)
+      end
+    end
+
+    nvim_lsp.jdtls.setup{
+      cmd = { "java-language-server", "--heap-max", "8G" };
+      init_options = {
+        bundles = {vim.env.HOME.."/language-servers/java/extensions/debug.jar"};
+      };
+      on_attach = on_attach;
+    }
+
+    nvim_lsp.gopls.setup{
+      on_attach = on_attach;
+    }
+
+    nvim_lsp.bashls.setup{
+      on_attach = on_attach;
+    }
+  end
+
+  local status, fzf_lsp = pcall(require, 'fzf_lsp')
+  if status then
+    fzf_lsp.setup()
+  end
+EOF
+
+endif

--- a/vimrc.bundles
+++ b/vimrc.bundles
@@ -102,6 +102,10 @@ Plug 'wellle/tmux-complete.vim'
 if v:version >= 800 || has('nvim')
   Plug 'w0rp/ale'
 endif
+if has('nvim-0.5')
+  Plug 'neovim/nvim-lspconfig'
+  Plug 'gfanto/fzf-lsp.nvim'
+endif
 if filereadable(expand("~/.vimrc.bundles.local"))
   source ~/.vimrc.bundles.local
 endif


### PR DESCRIPTION
Please use the following structure when proposing changes to our shared Vim configuration and make sure to complete the checklist at the end.

# What

Neovim 0.5 has support for native LSP. This PR detects when the user is running Neovim 0.5, and configures the editor's native LSP over `vim-lsp`.

# Why

So that users interested in using Neovim's native LSP support can do so.

# Checklist

- [ ] Send RFC email to Braintree developers _if change may be impactful_. Please include a link to this PR so that discussion about the pros and cons of the change remains linked to the proposed changes. **Recent examples include**: addition of linter and completer, no longer removing end-of-line whitespace on save, changing to fzf for file lookup.
