### PR TITLE
Add treesitter support

### DIFF
--- a/config/nvim/init.vim
+++ b/config/nvim/init.vim
@@ -89,6 +89,33 @@ if has('nvim-0.5')
   if status then
     fzf_lsp.setup()
   end
+
+  local status, treesitter = pcall(require, 'nvim-treesitter.configs')
+  if status then
+    treesitter.setup{
+      -- List of supported languages can be found here: https://github.com/nvim-treesitter/nvim-treesitter#supported-languages
+      ensure_installed = {"bash", "c_sharp", "clojure", "comment", "css", "go", "graphql", "html", "java", "javascript", "json", "kotlin", "lua", "php", "python", "regex", "ruby", "rust", "scala", "toml", "typescript"},
+      highlight = {
+        enable = true
+      },
+      incremental_selection = {
+        enable = true,
+        keymaps = {
+          init_selection = "gnn",
+          node_incremental = "grn",
+          scope_incremental = "grc",
+          node_decremental = "grm",
+        },
+      },
+      indent = {
+        enable = true
+      },
+    }
+
+    vim.wo.foldmethod = 'expr'
+    vim.wo.foldexpr = 'nvim_treesitter#foldexpr()'
+    vim.o.foldlevelstart = 99
+  end
 EOF
 
 endif

--- a/vimrc.bundles
+++ b/vimrc.bundles
@@ -105,6 +105,7 @@ endif
 if has('nvim-0.5')
   Plug 'neovim/nvim-lspconfig'
   Plug 'gfanto/fzf-lsp.nvim'
+  Plug 'nvim-treesitter/nvim-treesitter', {'do': ':TSUpdate'}
 endif
 if filereadable(expand("~/.vimrc.bundles.local"))
   source ~/.vimrc.bundles.local


### PR DESCRIPTION
# What

This PR adds support for [treesitter](https://github.com/nvim-treesitter/nvim-treesitter#nvim-treesitter) to users of Neovim 0.5.

# Why

Treesitter offers improved syntax highlighting, folding, and buffer intelligence on which other tools can be built

# Checklist

- [ ] Send RFC email to Braintree developers _if change may be impactful_. Please include a link to this PR so that discussion about the pros and cons of the change remains linked to the proposed changes. **Recent examples include**: addition of linter and completer, no longer removing end-of-line whitespace on save, changing to fzf for file lookup.
