### PR TITLE
Add Global Overrides file in /etc/vim/vimrc.global

### DIFF
--- a/vimrc
+++ b/vimrc
@@ -547,14 +547,23 @@ augroup autoformat_settings
   autocmd FileType bzl AutoFormatBuffer buildifier
 augroup END
 
-"-------- Local Overrides
-""If you have options you'd like to override locally for
-"some reason (don't want to store something in a
-""publicly-accessible repository, machine-specific settings, etc.),
-"you can create a '.local_vimrc' file in your home directory
-""(ie: ~/.vimrc_local) and it will be 'sourced' here and override
-"any settings in this file.
+"-------- System Overrides
+"If you have options you'd like to override globally for some reason (don't
+"want to store something in a publicly-accessible repository, machine-specific
+"settings, etc.), you can create a 'vimrc.global' file in /etc/vim and it will
+"be 'sourced' here and override any settings in this file.
 ""
+if filereadable(expand("/etc/vim/vimrc.global"))
+  source /etc/vim/vimrc.global
+endif
+
+"-------- Local Overrides
+"If you have options you'd like to override locally for some reason (don't
+"want to store something in a publicly-accessible repository, machine-specific
+"settings, etc.), you can create a '.local_vimrc' file in your home directory
+"(ie: ~/.vimrc_local) and it will be 'sourced' here and override any settings
+"in this file or the above global setting.
+"
 "NOTE: YOU MAY NOT WANT TO ADD ANY LINES BELOW THIS
 if filereadable(expand('~/.vimrc_local'))
   source ~/.vimrc_local


### PR DESCRIPTION
# What

This allows per system, instead of just per user overrides.

# Why

If, for example, you want to allow your users to have specific personal overrides, but still don't want to store it in the global vim_dotfiles repo, you can now put them in /etc/vim/vimrc.global!


# Checklist

~- [ ] Send RFC email to Braintree developers _if change may be impactful_. Please include a link to this PR so that discussion about the pros and cons of the change remains linked to the proposed changes. **Recent examples include**: addition of linter and completer, no longer removing end-of-line whitespace on save, changing to fzf for file lookup.~

Additive change.
