### PR TITLE
Switch markdown syntax highlighter to vim's

### DIFF
--- a/ftplugin/markdown.vim
+++ b/ftplugin/markdown.vim
@@ -1,0 +1,13 @@
+let g:markdown_fenced_languages = [
+\  'bash=sh',
+\  'c',
+\  'c++=cpp',
+\  'cpp',
+\  'go',
+\  'html',
+\  'java',
+\  'javascript',
+\  'python',
+\  'ruby',
+\  'rust',
+\]

--- a/vimrc
+++ b/vimrc
@@ -65,10 +65,6 @@ set undolevels=1000 "maximum number of changes that can be undone
 " Color
 colorscheme vibrantink
 
-augroup markdown
-  au!
-  au BufNewFile,BufRead *.md,*.markdown setlocal filetype=ghmarkdown
-augroup END
 augroup Drakefile
   au!
   au BufNewFile,BufRead Drakefile,drakefile setlocal filetype=ruby
@@ -223,8 +219,6 @@ let g:fzf_action = {
   \ 'ctrl-x': 'split',
   \ 'ctrl-s': 'split',
   \ 'ctrl-v': 'vsplit' }
-
-let g:vim_markdown_folding_disabled = 1
 
 let g:go_fmt_command = "goimports"
 let g:go_highlight_trailing_whitespace_error = 0

--- a/vimrc.bundles
+++ b/vimrc.bundles
@@ -28,7 +28,8 @@ Plug 'elixir-lang/vim-elixir'
 Plug 'elubow/cql-vim'
 Plug 'fatih/vim-go', { 'do': ':GoInstallBinaries' }
 Plug 'Glench/Vim-Jinja2-Syntax'
-Plug 'godlygeek/tabular' | Plug 'plasticboy/vim-markdown'
+Plug 'godlygeek/tabular'
+Plug 'tpope/vim-markdown'
 Plug 'google/vim-jsonnet'
 Plug 'guns/vim-clojure-highlight'
 Plug 'guns/vim-clojure-static'
@@ -39,7 +40,6 @@ Plug 'jgdavey/vim-turbux', { 'branch': 'main' }
 Plug 'hashivim/vim-terraform'
 Plug 'jlanzarotta/bufexplorer', { 'commit': 'f3bbe12664b08038912faac586f6c0b5104325c3' }
 Plug 'jparise/vim-graphql', { 'commit': '7ecedede603d16de5cca5ccefbde14d642b0d697' }
-Plug 'jtratner/vim-flavored-markdown'
 Plug 'kshenoy/vim-signature'
 if expand('<sfile>') == '/etc/vim/vimrc.bundles'
   Plug 'junegunn/fzf', { 'tag': '0.19.0', 'dir': '/etc/vim/fzf', 'do': './install --bin' }


### PR DESCRIPTION
Prior to this commit we were using 'jtratner/vim-flavored-markdown' to
augment the builtin highlighter, however it has some annoying bugs,
especially with [markdown lists](https://github.com/jtratner/vim-flavored-markdown/issues/24). It also appears to be a dead project.

So switch to vim's builtin highlighter whose development is maintained
by [tpope](https://github.com/tpope/vim-markdown) and configure the set of highlighters for fenced code blocks in 
addition.

Also remove 'plasticboy/vim-markdown' which offers similar features, but
I didn't see a compelling reason to use it versus the built in
highlighter.