### PR TITLE
Add vim-easy-align, and bind extra GHE-flavored markdown table commands

### DIFF
--- a/vimrc
+++ b/vimrc
@@ -344,6 +344,16 @@ map <silent> <LocalLeader>nt :NERDTreeToggle<CR>
 map <silent> <LocalLeader>nr :NERDTree<CR>
 map <silent> <LocalLeader>nf :NERDTreeFind<CR>
 
+" EasyAlign
+" Start interactive EasyAlign in visual mode (e.g. vipga)
+xmap ga <Plug>(EasyAlign)
+" Start interactive EasyAlign for a motion/text object (e.g. gaip)
+nmap ga <Plug>(EasyAlign)
+" Visually select GHE-flavored markdown table, then press tab to align it
+au FileType markdown vmap <tab> :EasyAlign*<Bar><Enter>
+" In normal mode, press bar (|) to select table and align it
+au FileType markdown map <Bar> vip :EasyAlign*<Bar><Enter>
+
 " FZF
 function! SmartFuzzy()
   let root = split(system('git rev-parse --show-toplevel'), '\n')

--- a/vimrc.bundles
+++ b/vimrc.bundles
@@ -32,11 +32,12 @@ Plug 'godlygeek/tabular' | Plug 'plasticboy/vim-markdown'
 Plug 'google/vim-jsonnet'
 Plug 'guns/vim-clojure-highlight'
 Plug 'guns/vim-clojure-static'
+Plug 'hashivim/vim-terraform'
 Plug 'henrik/vim-indexed-search'
 Plug 'janko-m/vim-test'
 Plug 'jergason/scala.vim'
 Plug 'jgdavey/vim-turbux', { 'branch': 'main' }
-Plug 'hashivim/vim-terraform'
+Plug 'junegunn/vim-easy-align'
 Plug 'jlanzarotta/bufexplorer', { 'commit': 'f3bbe12664b08038912faac586f6c0b5104325c3' }
 Plug 'jparise/vim-graphql', { 'commit': '7ecedede603d16de5cca5ccefbde14d642b0d697' }
 Plug 'jtratner/vim-flavored-markdown'


### PR DESCRIPTION


# What

Adds the [vim-easy-align](https://github.com/junegunn/vim-easy-align) plugin and binds both the generic commands as well as some ones specifically for GHE-flavored markdown tables.

The first two binds are from the vim-easy-align README. The second two binds are from this helpful blog post: https://calebeby.gitlab.io/blog/2016/formatting-markdown-tables-in-vim/

# Why

This makes auto-formatting markdown tables a breeze.

# Checklist

- [ ] Send RFC email to Braintree developers _if change may be impactful_. Please include a link to this PR so that discussion about the pros and cons of the change remains linked to the proposed changes. **Recent examples include**: addition of linter and completer, no longer removing end-of-line whitespace on save, changing to fzf for file lookup.