### PR TITLE
Initialize jdtls language server with java-test extension

### DIFF
--- a/config/nvim/init.vim
+++ b/config/nvim/init.vim
@@ -68,10 +68,12 @@ if has('nvim-0.5')
       end
     end
 
+    local jdtls_bundles = {vim.env.HOME.."/language-servers/java/extensions/debug.jar"};
+    vim.list_extend(jdtls_bundles, vim.split(vim.fn.glob(vim.env.HOME.."/language-servers/java/extensions/test/extension/server/*.jar"), "\n"))
     nvim_lsp.jdtls.setup{
       cmd = { "java-language-server", "--heap-max", "8G" };
       init_options = {
-        bundles = {vim.env.HOME.."/language-servers/java/extensions/debug.jar"};
+        bundles = jdtls_bundles;
       };
       on_attach = on_attach;
     }


### PR DESCRIPTION
# What

Add `java-test` server extension jars to the bundle list when initializing the `jdtls` language server.

# Why

This extension provides support for several new LSP commands that make it possible to discover and run Java tests.

# Checklist

- [ ] Send RFC email to Braintree developers _if change may be impactful_. Please include a link to this PR so that discussion about the pros and cons of the change remains linked to the proposed changes. **Recent examples include**: addition of linter and completer, no longer removing end-of-line whitespace on save, changing to fzf for file lookup.
