### PR TITLE
Add java-test extension bundles to vim-lsp initialization

### DIFF
--- a/vimrc
+++ b/vimrc
@@ -303,12 +303,14 @@ function! s:setup_vim_lsp() abort
         echoerr 'Function lsp#register_command() not found, please update your vim-lsp installation'
       endif
 
+      let l:bundles = ['/home/admin/language-servers/java/extensions/debug.jar']
+      call extend(l:bundles, split(glob($HOME."/language-servers/java/extensions/test/extension/server/*.jar"), "\n"))
       call lsp#register_server({
             \ 'name': 'java',
             \ 'cmd': {server_info->['java-language-server', '--heap-max', '8G']},
             \ 'allowlist': ['java'],
             \ 'initialization_options': {
-            \     'bundles': ['/home/admin/language-servers/java/extensions/debug.jar']
+            \     'bundles': l:bundles
             \ }
             \ })
     endfunction


### PR DESCRIPTION
# What

Initialize the `vim-lsp` plugin with the `java-test` extension bundles. This mimics the [existing configuration](https://github.com/braintreeps/vim_dotfiles/blob/fe210b3984f4bd438dc74bd9871edd2f760d4fcb/config/nvim/init.vim#L71-L79) of Neovim 0.5's native LSP client, but is compatible with Vim and Neovim < 0.5.

# Why

So that the extension is available to users of Vim and Neovim < 0.5.

# Checklist

- [ ] Send RFC email to Braintree developers _if change may be impactful_. Please include a link to this PR so that discussion about the pros and cons of the change remains linked to the proposed changes. **Recent examples include**: addition of linter and completer, no longer removing end-of-line whitespace on save, changing to fzf for file lookup.
