### PR TITLE
java: remove from markdown fenced languages

### DIFF
--- a/ftplugin/markdown.vim
+++ b/ftplugin/markdown.vim
@@ -1,3 +1,7 @@
+" Java's syntax highlighting breaks spell check,
+" so remove it, for more info see:
+" https://github.com/tpope/vim-markdown/issues/89
+" \  'java',
 let g:markdown_fenced_languages = [
 \  'bash=sh',
 \  'c',
@@ -5,7 +9,6 @@ let g:markdown_fenced_languages = [
 \  'cpp',
 \  'go',
 \  'html',
-\  'java',
 \  'javascript',
 \  'python',
 \  'ruby',


### PR DESCRIPTION
Using multiple syntax highlighters at the same time can cause problems.
Java's syntax highlighting breaks spell check, which is nice to have in
markdown files, so remove it, see
https://github.com/tpope/vim-markdown/issues/89 for more info.