### PR TITLE
Highlight do end in Tomorrow-Night

### DIFF
--- a/colors/Tomorrow-Night.vim
+++ b/colors/Tomorrow-Night.vim
@@ -318,6 +318,7 @@ if has("gui_running") || &t_Co == 88 || &t_Co == 256
 	call <SID>X("rubyInterpolationDelimiter", s:orange, "", "")
 	call <SID>X("rubyConditional", s:purple, "", "")
 	call <SID>X("rubyRepeat", s:purple, "", "")
+	call <SID>X("rubyControl", s:purple, "", "")
 
 	" Python Highlighting
 	call <SID>X("pythonInclude", s:purple, "", "")


### PR DESCRIPTION
# What

Add `rubyControl` to the Tomorrow-Night colorscheme.

# Why

The Tomorrow-Night colorscheme doesn't currently highlight `do` and `end` in Ruby code. It would make me happy if it did 😃 

# Checklist

- [ ] Send RFC email to Braintree developers _if change may be impactful_. Please include a link to this PR so that discussion about the pros and cons of the change remains linked to the proposed changes. **Recent examples include**: addition of linter and completer, no longer removing end-of-line whitespace on save, changing to fzf for file lookup.
