### PR TITLE
markdown: auto format markdown files with pandoc

### DIFF
--- a/ftplugin/markdown.vim
+++ b/ftplugin/markdown.vim
@@ -14,3 +14,5 @@ let g:markdown_fenced_languages = [
 \  'ruby',
 \  'rust',
 \]
+" auto format markdown files with pandoc
+let g:ale_fixers['markdown'] = ['pandoc']


### PR DESCRIPTION
This adds pandoc as a fixer for markdown files, formatting them with
pandoc. I find this to greatly increase the ease of composing markdown
in vim as lines are broken by pandoc at 72 and it is easier to spot
errors since pandoc will format based on its parsing of the document.