### PR TITLE
Pin nvim-treesitter to 0.5-compat branch

### DIFF
--- a/vimrc.bundles
+++ b/vimrc.bundles
@@ -106,7 +106,7 @@ endif
 if has('nvim-0.5')
   Plug 'neovim/nvim-lspconfig'
   Plug 'gfanto/fzf-lsp.nvim'
-  Plug 'nvim-treesitter/nvim-treesitter', {'do': ':TSUpdate'}
+  Plug 'nvim-treesitter/nvim-treesitter', {'branch': '0.5-compat', 'do': ':TSUpdate'}
 endif
 if filereadable(expand("~/.vimrc.bundles.local"))
   source ~/.vimrc.bundles.local


### PR DESCRIPTION

# What

Pin `nvim-treesitter` to the `0.5-compat` branch.

# Why

This branch is recommended for users of 0.5, which should be the
standard for a while.

See:
https://github.com/nvim-treesitter/nvim-treesitter/commit/20b5dd9893e1e7bc450dbed74d116123bb0ba2e3

# Checklist

- [ ] Send RFC email to Braintree developers _if change may be impactful_. Please include a link to this PR so that discussion about the pros and cons of the change remains linked to the proposed changes. **Recent examples include**: addition of linter and completer, no longer removing end-of-line whitespace on save, changing to fzf for file lookup.
