### PR TITLE
Add telescope when using Neovim 0.5

### DIFF
--- a/vimrc.bundles
+++ b/vimrc.bundles
@@ -106,7 +106,8 @@ if v:version >= 800 || has('nvim')
 endif
 if has('nvim-0.5')
   Plug 'neovim/nvim-lspconfig'
-  Plug 'gfanto/fzf-lsp.nvim'
+  Plug 'nvim-lua/plenary.nvim' " Required for telescope
+  Plug 'nvim-telescope/telescope.nvim'
   Plug 'nvim-treesitter/nvim-treesitter', {'branch': '0.5-compat', 'do': ':TSUpdate'}
 endif
 if filereadable(expand("~/.vimrc.bundles.local"))


### PR DESCRIPTION
# What

Install [Telescope](https://github.com/nvim-telescope/telescope.nvim) for users of Neovim 0.5, and configure LSP commands to use Telescope pickers where available.

# Why

Neovim LSP's default behavior for some tasks, notably running code actions, is not great. It uses the default Vim input mechanism, which provides a long list of items, and prompts for a number. `fzf-lsp.nvim` was installed in order to make that experience better, but recently it has not been working, presumably due to some updates that broke behavior. Telescope is a functional alternative that provides a much more usable, searchable list for code actions and other tasks.

In addition to being useful for users of LSP, Telescope has many other features as well, providing a lot of options for those who want to take full advantage of its features. Its Github repo has over 3.5k stars, so you _know_ it's good. 😄 

# Checklist

- [ ] Send RFC email to Braintree developers _if change may be impactful_. Please include a link to this PR so that discussion about the pros and cons of the change remains linked to the proposed changes. **Recent examples include**: addition of linter and completer, no longer removing end-of-line whitespace on save, changing to fzf for file lookup.
