### PR TITLE
Add support for nvim-dap and nvim-jdtls

### DIFF
--- a/activate.sh
+++ b/activate.sh
@@ -3,7 +3,7 @@
 set -euo pipefail
 
 dotfiles_dir=$(cd "$(dirname "$0")"; pwd)
-mkdir -p "${HOME}/.config/nvim"
+mkdir -p "${HOME}/.config/nvim" "${HOME}/.config/nvim/lua"
 
 if ! vim --version | grep -q '2nd user vimrc file'; then
   for name in vim vimrc vimrc.bundles; do
@@ -11,7 +11,7 @@ if ! vim --version | grep -q '2nd user vimrc file'; then
     ln -s "${dotfiles_dir}/${name}" "${HOME}/.${name}"
   done
 fi
-for name in config/nvim/init.vim; do
+for name in config/nvim/init.vim config/nvim/lua/lsp_on_attach.lua; do
   rm -rf "${HOME}/.${name}"
   ln -s "${dotfiles_dir}/${name}" "${HOME}/.${name}"
 done

--- a/config/nvim/init.vim
+++ b/config/nvim/init.vim
@@ -6,77 +6,7 @@ if has('nvim-0.5')
   lua << EOF
   local status, nvim_lsp = pcall(require, 'lspconfig')
   if status then
-    local on_attach = function(client, bufnr)
-      local function buf_set_keymap(...) vim.api.nvim_buf_set_keymap(bufnr, ...) end
-      local function buf_set_option(...) vim.api.nvim_buf_set_option(bufnr, ...) end
-
-      buf_set_option('omnifunc', 'v:lua.vim.lsp.omnifunc')
-
-      -- Mappings.
-      local opts = { noremap=true, silent=true }
-
-      -- Inspired by https://github.com/neovim/nvim-lspconfig/#keybindings-and-completion,
-      -- but with <leader> instead of <space>
-
-      -- Navigation
-      buf_set_keymap('n', 'gD', '<Cmd>lua vim.lsp.buf.declaration()<CR>', opts)
-      buf_set_keymap('n', 'gd', '<Cmd>lua vim.lsp.buf.definition()<CR>', opts)
-      buf_set_keymap('n', '<Leader>D', '<cmd>lua vim.lsp.buf.type_definition()<CR>', opts)
-
-      -- Information
-      buf_set_keymap('n', 'K', '<Cmd>lua vim.lsp.buf.hover()<CR>', opts)
-      buf_set_keymap('n', 'gi', '<cmd>lua vim.lsp.buf.implementation()<CR>', opts)
-      buf_set_keymap('n', '<C-k>', '<cmd>lua vim.lsp.buf.signature_help()<CR>', opts)
-      buf_set_keymap('n', 'gr', '<cmd>lua vim.lsp.buf.references()<CR>', opts)
-      buf_set_keymap('n', '<Leader>ds', '<cmd>lua vim.lsp.buf.document_symbol()<CR>', opts)
-
-      -- Diagnostics
-      buf_set_keymap('n', '[d', '<cmd>lua vim.lsp.diagnostic.goto_prev()<CR>', opts)
-      buf_set_keymap('n', ']d', '<cmd>lua vim.lsp.diagnostic.goto_next()<CR>', opts)
-      buf_set_keymap('n', '<Leader>e', '<cmd>lua vim.lsp.diagnostic.show_line_diagnostics()<CR>', opts)
-      buf_set_keymap('n', '<Leader>q', '<cmd>lua vim.lsp.diagnostic.set_loclist()<CR>', opts)
-
-      -- Refactoring
-      buf_set_keymap('n', '<Leader>rn', '<cmd>lua vim.lsp.buf.rename()<CR>', opts)
-      buf_set_keymap('n', '<Leader>ca', '<cmd>lua vim.lsp.buf.code_action()<CR>', opts)
-
-      -- Workspaces
-      buf_set_keymap('n', '<Leader>wa', '<cmd>lua vim.lsp.buf.add_workspace_folder()<CR>', opts)
-      buf_set_keymap('n', '<Leader>wr', '<cmd>lua vim.lsp.buf.remove_workspace_folder()<CR>', opts)
-      buf_set_keymap('n', '<Leader>wl', '<cmd>lua print(vim.inspect(vim.lsp.buf.list_workspace_folders()))<CR>', opts)
-      buf_set_keymap('n', '<Leader>ws', '<cmd>lua vim.lsp.buf.workspace_symbol()<CR>', opts)
-
-      -- Set some keybinds conditional on server capabilities
-      if client.resolved_capabilities.document_formatting then
-        buf_set_keymap("n", "<Leader>fd", "<cmd>lua vim.lsp.buf.formatting()<CR>", opts)
-      elseif client.resolved_capabilities.document_range_formatting then
-        buf_set_keymap("n", "<Leader>fd", "<cmd>lua vim.lsp.buf.formatting()<CR>", opts)
-      end
-
-      -- Set autocommands conditional on server_capabilities
-      if client.resolved_capabilities.document_highlight then
-        vim.api.nvim_exec([[
-          hi LspReferenceRead cterm=bold ctermbg=red guibg=LightYellow
-          hi LspReferenceText cterm=bold ctermbg=red guibg=LightYellow
-          hi LspReferenceWrite cterm=bold ctermbg=red guibg=LightYellow
-          augroup lsp_document_highlight
-            autocmd!
-            autocmd CursorHold <buffer> lua vim.lsp.buf.document_highlight()
-            autocmd CursorMoved <buffer> lua vim.lsp.buf.clear_references()
-          augroup END
-        ]], false)
-      end
-    end
-
-    local jdtls_bundles = {vim.env.HOME.."/language-servers/java/extensions/debug.jar"};
-    vim.list_extend(jdtls_bundles, vim.split(vim.fn.glob(vim.env.HOME.."/language-servers/java/extensions/test/extension/server/*.jar"), "\n"))
-    nvim_lsp.jdtls.setup{
-      cmd = { "java-language-server", "--heap-max", "8G" };
-      init_options = {
-        bundles = jdtls_bundles;
-      };
-      on_attach = on_attach;
-    }
+    local on_attach = require('lsp_on_attach')
 
     nvim_lsp.gopls.setup{
       on_attach = on_attach;
@@ -118,6 +48,25 @@ if has('nvim-0.5')
     vim.wo.foldexpr = 'nvim_treesitter#foldexpr()'
     vim.o.foldlevelstart = 99
   end
+
+  vim.api.nvim_exec([[
+    nnoremap <silent> <F5> :lua require('dap').continue()<cr>
+    nnoremap <silent> <F10> :lua require('dap').step_over()<cr>
+    nnoremap <silent> <F11> :lua require('dap').step_into()<cr>
+    nnoremap <silent> <F12> :lua require('dap').step_out()<cr>
+
+    nnoremap <silent> <Leader>bb :lua require('dap').toggle_breakpoint()<cr>
+    nnoremap <silent> <Leader>bl :lua require('dap').list_breakpoints()<cr>
+    nnoremap <silent> <Leader>bc :lua require('dap').set_breakpoint(vim.fn.input('Breakpoint condition: '))<cr>
+    nnoremap <silent> <Leader>bL :lua require('dap').set_breakpoint(nil, nil, vim.fn.input('Log point message: '))<cr>
+    nnoremap <silent> <Leader>dr :lua require('dap').repl.open()<cr>
+    nnoremap <silent> <Leader>dl :lua require('dap').run_last()<cr>
+
+    command! Continue :lua require('dap').continue()<cr>
+    command! StepOver :lua require('dap').step_over()<cr>
+    command! StepInto :lua require('dap').step_into()<cr>
+    command! StepOut :lua require('dap').step_out()<cr>
+  ]], false)
 EOF
 
 endif

--- a/config/nvim/lua/lsp_on_attach.lua
+++ b/config/nvim/lua/lsp_on_attach.lua
@@ -1,0 +1,63 @@
+local function on_attach(client, bufnr)
+  local function buf_set_keymap(...) vim.api.nvim_buf_set_keymap(bufnr, ...) end
+  local function buf_set_option(...) vim.api.nvim_buf_set_option(bufnr, ...) end
+
+  buf_set_option('omnifunc', 'v:lua.vim.lsp.omnifunc')
+
+  -- Mappings.
+  local opts = { noremap=true, silent=true }
+
+  -- Inspired by https://github.com/neovim/nvim-lspconfig/#keybindings-and-completion,
+  -- but with <leader> instead of <space>
+
+  -- Navigation
+  buf_set_keymap('n', 'gD', '<Cmd>lua vim.lsp.buf.declaration()<CR>', opts)
+  buf_set_keymap('n', 'gd', '<Cmd>lua vim.lsp.buf.definition()<CR>', opts)
+  buf_set_keymap('n', '<Leader>D', '<cmd>lua vim.lsp.buf.type_definition()<CR>', opts)
+
+  -- Information
+  buf_set_keymap('n', 'K', '<Cmd>lua vim.lsp.buf.hover()<CR>', opts)
+  buf_set_keymap('n', 'gi', '<cmd>lua vim.lsp.buf.implementation()<CR>', opts)
+  buf_set_keymap('n', '<C-k>', '<cmd>lua vim.lsp.buf.signature_help()<CR>', opts)
+  buf_set_keymap('n', 'gr', '<cmd>lua vim.lsp.buf.references()<CR>', opts)
+  buf_set_keymap('n', '<Leader>ds', '<cmd>lua vim.lsp.buf.document_symbol()<CR>', opts)
+
+  -- Diagnostics
+  buf_set_keymap('n', '[d', '<cmd>lua vim.lsp.diagnostic.goto_prev()<CR>', opts)
+  buf_set_keymap('n', ']d', '<cmd>lua vim.lsp.diagnostic.goto_next()<CR>', opts)
+  buf_set_keymap('n', '<Leader>e', '<cmd>lua vim.lsp.diagnostic.show_line_diagnostics()<CR>', opts)
+  buf_set_keymap('n', '<Leader>q', '<cmd>lua vim.lsp.diagnostic.set_loclist()<CR>', opts)
+
+  -- Refactoring
+  buf_set_keymap('n', '<Leader>rn', '<cmd>lua vim.lsp.buf.rename()<CR>', opts)
+  --buf_set_keymap('n', '<Leader>ca', '<cmd>lua vim.lsp.buf.code_action()<CR>', opts)
+
+  -- Workspaces
+  buf_set_keymap('n', '<Leader>wa', '<cmd>lua vim.lsp.buf.add_workspace_folder()<CR>', opts)
+  buf_set_keymap('n', '<Leader>wr', '<cmd>lua vim.lsp.buf.remove_workspace_folder()<CR>', opts)
+  buf_set_keymap('n', '<Leader>wl', '<cmd>lua print(vim.inspect(vim.lsp.buf.list_workspace_folders()))<CR>', opts)
+  buf_set_keymap('n', '<Leader>ws', '<cmd>lua vim.lsp.buf.workspace_symbol()<CR>', opts)
+
+  -- Set some keybinds conditional on server capabilities
+  if client.resolved_capabilities.document_formatting then
+    buf_set_keymap("n", "<Leader>fd", "<cmd>lua vim.lsp.buf.formatting()<CR>", opts)
+  elseif client.resolved_capabilities.document_range_formatting then
+    buf_set_keymap("n", "<Leader>fd", "<cmd>lua vim.lsp.buf.formatting()<CR>", opts)
+  end
+
+  -- Set autocommands conditional on server_capabilities
+  if client.resolved_capabilities.document_highlight then
+    vim.api.nvim_exec([[
+    hi LspReferenceRead cterm=bold ctermbg=red guibg=LightYellow
+    hi LspReferenceText cterm=bold ctermbg=red guibg=LightYellow
+    hi LspReferenceWrite cterm=bold ctermbg=red guibg=LightYellow
+    augroup lsp_document_highlight
+    autocmd!
+    autocmd CursorHold <buffer> lua vim.lsp.buf.document_highlight()
+    autocmd CursorMoved <buffer> lua vim.lsp.buf.clear_references()
+    augroup END
+    ]], false)
+  end
+end
+
+return on_attach

--- a/ftplugin/java.lua
+++ b/ftplugin/java.lua
@@ -1,0 +1,46 @@
+local status, jdtls = pcall(require, 'jdtls')
+if status then
+  local function jdtls_on_attach(client, bufnr)
+    require('lsp_on_attach')(client, bufnr)
+
+    jdtls.setup_dap({ hotcodereplace = 'auto' })
+    jdtls.setup.add_commands()
+    -- TODO: add other shortcuts?
+    -- https://github.com/mfussenegger/dotfiles/blob/89a0acc43ac1d8c2ee475a00b8a448a23b8c1c26/vim/.config/nvim/lua/lsp-config.lua#L90-L95
+
+    local function buf_set_keymap(...) vim.api.nvim_buf_set_keymap(bufnr, ...) end
+    local opts = { noremap=true, silent=true }
+
+    function notify_and_run(method)
+      print('Executing...')
+      vim.schedule(method)
+    end
+
+    buf_set_keymap('n', '<Leader>db', '<cmd>lua notify_and_run(require("jdtls").test_class)<CR>', opts)
+    buf_set_keymap('n', '<Leader>ca', '<cmd>lua notify_and_run(require("jdtls").code_action)<CR>', opts)
+    buf_set_keymap('n', '<Leader>df', '<cmd>lua notify_and_run(require("jdtls").test_nearest_method)<CR>', opts)
+  end
+
+  local jdtls_bundles = {vim.env.HOME.."/language-servers/java/extensions/debug.jar"};
+  for _, bundle in ipairs(vim.split(vim.fn.glob(vim.env.HOME.."/language-servers/java/extensions/test/extension/server/*.jar"), "\n")) do
+    if not vim.endswith(bundle, 'com.microsoft.java.test.runner.jar') then
+      table.insert(jdtls_bundles, bundle)
+    end
+  end
+
+  -- TODO: add the vscode-java-decompiler plugin?
+
+  local extendedClientCapabilities = jdtls.extendedClientCapabilities;
+  extendedClientCapabilities.resolveAdditionalTextEditsSupport = true;
+
+  local config = {
+    cmd = {'java-language-server', '--heap-max', '8G'};
+    init_options = {
+      bundles = jdtls_bundles;
+      extendedClientCapabilities = extendedClientCapabilities;
+    };
+    on_attach = jdtls_on_attach;
+  }
+
+  jdtls.start_or_attach(config)
+end

--- a/vimrc.bundles
+++ b/vimrc.bundles
@@ -108,6 +108,8 @@ if has('nvim-0.5')
   Plug 'neovim/nvim-lspconfig'
   Plug 'gfanto/fzf-lsp.nvim'
   Plug 'nvim-treesitter/nvim-treesitter', {'branch': '0.5-compat', 'do': ':TSUpdate'}
+  Plug 'mfussenegger/nvim-dap'
+  Plug 'mfussenegger/nvim-jdtls'
 endif
 if filereadable(expand("~/.vimrc.bundles.local"))
   source ~/.vimrc.bundles.local


### PR DESCRIPTION
# What

Add the `nvim-dap` and `nvim-jdtls` plugins and configure them.

# Why

These plugins provide better support for editing and debugging Java code than what we currently have.

One caveat is that it may conflict slightly with https://github.com/braintreeps/vim_dotfiles/pull/201, since the picker is likely not aware of `nvim-jdtls`'s implementation of code actions, so some additional work may be needed in order to get these two PRs to play nicely.

# Checklist

- [ ] Send RFC email to Braintree developers _if change may be impactful_. Please include a link to this PR so that discussion about the pros and cons of the change remains linked to the proposed changes. **Recent examples include**: addition of linter and completer, no longer removing end-of-line whitespace on save, changing to fzf for file lookup.
