### PR TITLE
Configure Java test runner for Gradle projects

### DIFF
--- a/vimrc
+++ b/vimrc
@@ -236,6 +236,8 @@ if filereadable(expand('WORKSPACE'))
   let test#java#runner = 'bazeltest'
   let g:test#java#bazeltest#test_executable = './bazel test'
   let g:test#java#bazeltest#file_pattern = '.*/test/.*\.java$'
+elseif filereadable('settings.gradle') || executable('gradlew')
+  let test#java#runner = 'gradletest'
 endif
 
 let g:lsp_diagnostics_echo_cursor = 1


### PR DESCRIPTION
# What

Configure the `vim-test` plugin for Gradle-based Java projects.

# Why

So that the standard test-runner shortcuts work as expected for Gradle projects.

# Checklist

- [ ] Send RFC email to Braintree developers _if change may be impactful_. Please include a link to this PR so that discussion about the pros and cons of the change remains linked to the proposed changes. **Recent examples include**: addition of linter and completer, no longer removing end-of-line whitespace on save, changing to fzf for file lookup.
