### PR TITLE
Add vim-rake and use vim-projectionist for all file types

### DIFF
--- a/vimrc.bundles
+++ b/vimrc.bundles
@@ -71,13 +71,14 @@ Plug 'tomtom/tcomment_vim'
 Plug 'tpope/vim-cucumber'
 Plug 'tpope/vim-endwise'
 Plug 'tpope/vim-salve', { 'for': 'clojure' }
-Plug 'tpope/vim-projectionist', { 'for': 'clojure' }
+Plug 'tpope/vim-projectionist'
 Plug 'tpope/vim-dispatch', { 'for': 'clojure' }
 Plug 'tpope/vim-fireplace', { 'for': 'clojure' }
 Plug 'tpope/vim-sexp-mappings-for-regular-people', { 'for': 'clojure' }
 Plug 'guns/vim-sexp', { 'for': 'clojure' }
 Plug 'tpope/vim-fugitive'
 Plug 'tpope/vim-ragtag'
+Plug 'tpope/vim-rake'
 Plug 'tpope/vim-rails'
 Plug 'tpope/vim-repeat'
 Plug 'tpope/vim-rhubarb'


### PR DESCRIPTION
# What

This adds `vim-rake` to introduce commands like `:A`, `:AS`, `:AV`, etc. for Ruby codebases that are not Rails apps, allowing developers to quickly navigate to corresponding spec files. This still requires adding a `.projections.json` file to your app to specify the alternate file pattern. See [tpope/vim-projectionist#alternate-files](https://github.com/tpope/vim-projectionist#alternate-files) for an example of a `.projections.json` file.

# Why

Limiting the `vim-projectionist` plugin disallows the `.projections.json` file from affecting Ruby codebases that are not Rails applications. Adding `vim-rake` is recommended in [the vim-rails FAQ](https://github.com/tpope/vim-rails#faq) when needing something for non-Rails codebases.