### PR TITLE
Add ranmason improvements

### DIFF
--- a/.gitmodules
+++ b/.gitmodules
@@ -1,0 +1,3 @@
+[submodule "plugins/tpm"]
+	path = plugins/tpm
+	url = https://github.com/tmux-plugins/tpm

--- a/.gitmodules
+++ b/.gitmodules
@@ -1,3 +1,0 @@
-[submodule "plugins/tpm"]
-	path = plugins/tpm
-	url = https://github.com/tmux-plugins/tpm

--- a/README.md
+++ b/README.md
@@ -15,7 +15,7 @@ After cloning this project, run `~/.vim/activate.sh`.
 Uses `vim-plug` to manage bundles.
 
 We have included our `tmux.conf` as `tmux_example.conf`.  To use some of the
-vimmux :magic:, please link that  to ~/.tmux.conf:
+vimmux :magic:, please link that  to `~/.tmux.conf`:
 
 `ln -s ~/.vim/tmux_example.conf ~/.tmux.conf`
 

--- a/tmux_example.conf
+++ b/tmux_example.conf
@@ -1,10 +1,12 @@
 # split windows like vim
 # vim's definition of a horizontal/vertical split is reversed from tmux's
 bind s split-window -v -c "#{pane_current_path}"
-bind v split-window -h -c '#{pane_current_path}'
-
 bind ^s split-window -v -c "#{pane_current_path}"
+bind _ split-window -fv -c "#{pane_current_path}"
+
+bind v split-window -h -c '#{pane_current_path}'
 bind ^v split-window -h -c "#{pane_current_path}"
+bind | split-window -fh -c '#{pane_current_path}'
 
 # open panes in same path when using canonical tmux splits
 bind '"' split-window -c "#{pane_current_path}"

--- a/tmux_example.conf
+++ b/tmux_example.conf
@@ -200,6 +200,7 @@ if-shell "test -f /usr/local/bin/reattach-to-user-namespace" 'set-option -g defa
 # List of plugins
 set -g @plugin 'tmux-plugins/tpm'
 set -g @plugin 'tmux-plugins/tmux-resurrect'
+set -g @plugin 'tmux-plugins/tmux-sensible'
 
 # override default resurrect bindings to avoid conflict with existing shortcut
 set -g @resurrect-save 'Z'

--- a/tmux_example.conf
+++ b/tmux_example.conf
@@ -198,8 +198,8 @@ bind y run 'tmux showw synchronize-panes | grep " on" >/dev/null && tmux set syn
 # Save tmux history - http://unix.stackexchange.com/questions/26548/write-all-tmux-scrollback-to-a-file
 bind S command-prompt -p 'save history to filename:' -I '/tmp/tmux.history' 'capture-pane -S -32768 ; save-buffer %1 ; delete-buffer'
 
-# Source extra cpair vim config if it exists
-if-shell "test -f /etc/tmux_cpair.conf" "source /etc/tmux_cpair.conf"
+# Source extra global tmux config if it exists
+if-shell "test -f /etc/tmux.conf.global" "source /etc/tmux.conf.global"
 if-shell 'test -f ~/.tmux.conf.user' 'source ~/.tmux.conf.user'
 
 # Fix copy/paste on MacOS: https://thoughtbot.com/blog/how-to-copy-and-paste-with-tmux-on-mac-os-x

--- a/tmux_example.conf
+++ b/tmux_example.conf
@@ -192,6 +192,9 @@ bind c new-window -c '#{pane_current_path}'
 bind B confirm-before -p "Change prefix to C-b?" 'set -g prefix ^b'
 bind A confirm-before -p "Change prefix to C-a?" 'set -g prefix ^a'
 
+# Toggle synchronize-panes with C-a y
+bind y run 'tmux showw synchronize-panes | grep " on" >/dev/null && tmux set synchronize-panes || tmux run -C "confirm-before -p \"Synchronize panes?\" \"set synchronize-panes\""'
+
 # Save tmux history - http://unix.stackexchange.com/questions/26548/write-all-tmux-scrollback-to-a-file
 bind S command-prompt -p 'save history to filename:' -I '/tmp/tmux.history' 'capture-pane -S -32768 ; save-buffer %1 ; delete-buffer'
 

--- a/tmux_example.conf
+++ b/tmux_example.conf
@@ -47,7 +47,6 @@ bind : command-prompt
 # Confirm before changing your bespoke layout to zebra stripes
 bind Space confirm next-layout
 
-
 bind C-d if -F '#{session_many_attached}' \
     'confirm-before -p "Detach other clients? (y/n)" "detach -a"' \
     'display "Session has only 1 client attached"'

--- a/tmux_example.conf
+++ b/tmux_example.conf
@@ -204,7 +204,6 @@ if-shell "test -f /usr/local/bin/reattach-to-user-namespace" 'set-option -g defa
 # List of plugins
 set -g @plugin 'tmux-plugins/tpm'
 set -g @plugin 'tmux-plugins/tmux-resurrect'
-set -g @plugin 'tmux-plugins/tmux-sensible'
 
 # override default resurrect bindings to avoid conflict with existing shortcut
 set -g @resurrect-save 'Z'

--- a/tmux_example.conf
+++ b/tmux_example.conf
@@ -206,6 +206,7 @@ if-shell "test -f /usr/local/bin/reattach-to-user-namespace" 'set-option -g defa
 set -g @plugin 'tmux-plugins/tpm'
 set -g @plugin 'tmux-plugins/tmux-resurrect'
 set -g @plugin 'tmux-plugins/tmux-sensible'
+set -g @plugin 'tmux-plugins/tmux-continuum'
 
 # override default resurrect bindings to avoid conflict with existing shortcut
 set -g @resurrect-save 'Z'

--- a/tmux_example.conf
+++ b/tmux_example.conf
@@ -12,7 +12,8 @@ bind | split-window -fh -c '#{pane_current_path}'
 bind '"' split-window -c "#{pane_current_path}"
 bind % split-window -h -c "#{pane_current_path}"
 
-bind '`' run -C "display-popup -d '#{pane_current_path}' -xC -yC -w'90%' -h'90%' -E 'tmux attach -t #S-popup || tmux new -s #S-popup'"
+if-shell "tmux -V | awk '{exit ($2 >= 3.2) ? 0 : 1}'" \
+   "bind '`' run -C \"display-popup -d '#{pane_current_path}' -xC -yC -w'90%' -h'90%' -E 'tmux attach -t #S-popup || tmux new -s #S-popup'\""
 
 # Provide command to generate a 2:1 ratio layout
 bind @ \

--- a/tmux_example.conf
+++ b/tmux_example.conf
@@ -209,7 +209,6 @@ if-shell "test -f /usr/local/bin/reattach-to-user-namespace" 'set-option -g defa
 set -g @plugin 'tmux-plugins/tpm'
 set -g @plugin 'tmux-plugins/tmux-resurrect'
 set -g @plugin 'tmux-plugins/tmux-sensible'
-set -g @plugin 'tmux-plugins/tmux-continuum'
 
 # override default resurrect bindings to avoid conflict with existing shortcut
 set -g @resurrect-save 'Z'

--- a/tmux_example.conf
+++ b/tmux_example.conf
@@ -10,7 +10,7 @@ bind ^v split-window -h -c "#{pane_current_path}"
 bind '"' split-window -c "#{pane_current_path}"
 bind % split-window -h -c "#{pane_current_path}"
 
-bind '`' display-popup -d '#{pane_current_path}' -xC -yC -w'90%' -h'90%' -K -E -R "tmux attach -t #S-popup || tmux new -s #S-popup"
+bind '`' run -C "display-popup -d '#{pane_current_path}' -xC -yC -w'90%' -h'90%' -E 'tmux attach -t #S-popup || tmux new -s #S-popup'"
 
 # Provide command to generate a 2:1 ratio layout
 bind @ \
@@ -64,7 +64,7 @@ bind-key R move-window -r
 
 bind ^a last-window # toggle last window like screen
 
-set -g update-environment "DISPLAY WINDOWID SSH_ASKPASS SSH_AGENT_PID SSH_CONNECTION"
+set -g update-environment "DISPLAY WINDOWID SSH_AUTH_SOCK SSH_ASKPASS SSH_AGENT_PID SSH_CONNECTION"
 
 bind K confirm kill-server
 bind X confirm kill-window

--- a/tmux_example.conf
+++ b/tmux_example.conf
@@ -10,6 +10,8 @@ bind ^v split-window -h -c "#{pane_current_path}"
 bind '"' split-window -c "#{pane_current_path}"
 bind % split-window -h -c "#{pane_current_path}"
 
+bind '`' display-popup -d '#{pane_current_path}' -xC -yC -w'90%' -h'90%' -K -E -R "tmux attach -t #S-popup || tmux new -s #S-popup"
+
 # Provide command to generate a 2:1 ratio layout
 bind @ \
   split-window -h -c "#{pane_current_path}" -p 33 \;\

--- a/tmux_example.conf
+++ b/tmux_example.conf
@@ -208,6 +208,7 @@ set -g @plugin 'tmux-plugins/tmux-sensible'
 # override default resurrect bindings to avoid conflict with existing shortcut
 set -g @resurrect-save 'Z'
 set -g @resurrect-restore 'R'
+set -g @resurrect-processes 'ssh'
 
 # Initialize TMUX plugin manager (keep this line at the very bottom of tmux.conf)
 run '~/.tmux/plugins/tpm/tpm'

--- a/tmux_example.conf
+++ b/tmux_example.conf
@@ -46,6 +46,11 @@ bind : command-prompt
 # Confirm before changing your bespoke layout to zebra stripes
 bind Space confirm next-layout
 
+
+bind C-d if -F '#{session_many_attached}' \
+    'confirm-before -p "Detach other clients? (y/n)" "detach -a"' \
+    'display "Session has only 1 client attached"'
+
 # session management
 bind C new-session
 bind L choose-session

--- a/tmux_example.conf
+++ b/tmux_example.conf
@@ -192,6 +192,7 @@ bind-key S command-prompt -p 'save history to filename:' -I '/tmp/tmux.history' 
 
 # Source extra cpair vim config if it exists
 if-shell "test -f /etc/tmux_cpair.conf" "source /etc/tmux_cpair.conf"
+if-shell 'test -f ~/.tmux.conf.user' 'source ~/.tmux.conf.user'
 
 # List of plugins
 set -g @plugin 'tmux-plugins/tpm'

--- a/tmux_example.conf
+++ b/tmux_example.conf
@@ -139,9 +139,6 @@ if-shell "tmux -V | awk '{exit ($2 >= 2.9) ? 0 : 1}'" \
   'set -g pane-border-style bg=default,fg=colour238 ;\
   set -g pane-active-border-style bg=default,fg=colour214'
 
-# set a 256color $TERM variable so programs inside tmux know they can use 256 colors
-set -g default-terminal screen-256color
-# reverted the following until all deployed instances have the lastest terminfo
 if-shell 'infocmp tmux-256color >/dev/null 2>&1' \
   "set -g default-terminal tmux-256color" \
   "set -g default-terminal screen-256color"

--- a/tmux_example.conf
+++ b/tmux_example.conf
@@ -198,10 +198,6 @@ bind y run 'tmux showw synchronize-panes | grep " on" >/dev/null && tmux set syn
 # Save tmux history - http://unix.stackexchange.com/questions/26548/write-all-tmux-scrollback-to-a-file
 bind S command-prompt -p 'save history to filename:' -I '/tmp/tmux.history' 'capture-pane -S -32768 ; save-buffer %1 ; delete-buffer'
 
-# Source extra global tmux config if it exists
-if-shell "test -f /etc/tmux.conf.global" "source /etc/tmux.conf.global"
-if-shell 'test -f ~/.tmux.conf.user' 'source ~/.tmux.conf.user'
-
 # Fix copy/paste on MacOS: https://thoughtbot.com/blog/how-to-copy-and-paste-with-tmux-on-mac-os-x
 if-shell "test -f /usr/local/bin/reattach-to-user-namespace" 'set-option -g default-command "reattach-to-user-namespace -l zsh"'
 
@@ -215,8 +211,10 @@ set -g @resurrect-save 'Z'
 set -g @resurrect-restore 'R'
 set -g @resurrect-processes 'ssh'
 
-# Local config
-if-shell "[ -f ~/.tmux.conf.user ]" 'source ~/.tmux.conf.user'
+# Source extra global tmux config if it exists
+if-shell "test -f /etc/tmux.conf.global" "source /etc/tmux.conf.global"
+# Source extra user tmux config if it exists
+if-shell 'test -f ~/.tmux.conf.user' 'source ~/.tmux.conf.user'
 
 # Initialize TMUX plugin manager (keep this line at the very bottom of tmux.conf)
 run '~/.tmux/plugins/tpm/tpm'

--- a/tmux_example.conf
+++ b/tmux_example.conf
@@ -194,6 +194,9 @@ bind-key S command-prompt -p 'save history to filename:' -I '/tmp/tmux.history' 
 if-shell "test -f /etc/tmux_cpair.conf" "source /etc/tmux_cpair.conf"
 if-shell 'test -f ~/.tmux.conf.user' 'source ~/.tmux.conf.user'
 
+# Fix copy/paste on MacOS: https://thoughtbot.com/blog/how-to-copy-and-paste-with-tmux-on-mac-os-x
+if-shell "test -f /usr/local/bin/reattach-to-user-namespace" 'set-option -g default-command "reattach-to-user-namespace -l zsh"'
+
 # List of plugins
 set -g @plugin 'tmux-plugins/tpm'
 set -g @plugin 'tmux-plugins/tmux-resurrect'
@@ -205,5 +208,3 @@ set -g @resurrect-restore 'R'
 # Initialize TMUX plugin manager (keep this line at the very bottom of tmux.conf)
 run '~/.tmux/plugins/tpm/tpm'
 
-# Fix copy/paste on MacOS: https://thoughtbot.com/blog/how-to-copy-and-paste-with-tmux-on-mac-os-x
-if-shell "test -f /usr/local/bin/reattach-to-user-namespace" 'set-option -g default-command "reattach-to-user-namespace -l zsh"'

--- a/tmux_example.conf
+++ b/tmux_example.conf
@@ -197,6 +197,9 @@ if-shell 'test -f ~/.tmux.conf.user' 'source ~/.tmux.conf.user'
 # Fix copy/paste on MacOS: https://thoughtbot.com/blog/how-to-copy-and-paste-with-tmux-on-mac-os-x
 if-shell "test -f /usr/local/bin/reattach-to-user-namespace" 'set-option -g default-command "reattach-to-user-namespace -l zsh"'
 
+# Local config
+if-shell "[ -f ~/.tmux.conf.user ]" 'source ~/.tmux.conf.user'
+
 # List of plugins
 set -g @plugin 'tmux-plugins/tpm'
 set -g @plugin 'tmux-plugins/tmux-resurrect'

--- a/tmux_example.conf
+++ b/tmux_example.conf
@@ -60,7 +60,7 @@ bind a send-prefix
 set -g base-index 1
 
 # Renumber tmux windows
-bind-key R move-window -r
+bind R move-window -r
 
 bind ^a last-window # toggle last window like screen
 
@@ -188,7 +188,7 @@ bind B confirm-before -p "Change prefix to C-b?" 'set -g prefix ^b'
 bind A confirm-before -p "Change prefix to C-a?" 'set -g prefix ^a'
 
 # Save tmux history - http://unix.stackexchange.com/questions/26548/write-all-tmux-scrollback-to-a-file
-bind-key S command-prompt -p 'save history to filename:' -I '/tmp/tmux.history' 'capture-pane -S -32768 ; save-buffer %1 ; delete-buffer'
+bind S command-prompt -p 'save history to filename:' -I '/tmp/tmux.history' 'capture-pane -S -32768 ; save-buffer %1 ; delete-buffer'
 
 # Source extra cpair vim config if it exists
 if-shell "test -f /etc/tmux_cpair.conf" "source /etc/tmux_cpair.conf"

--- a/tmux_example.conf
+++ b/tmux_example.conf
@@ -202,9 +202,6 @@ if-shell 'test -f ~/.tmux.conf.user' 'source ~/.tmux.conf.user'
 # Fix copy/paste on MacOS: https://thoughtbot.com/blog/how-to-copy-and-paste-with-tmux-on-mac-os-x
 if-shell "test -f /usr/local/bin/reattach-to-user-namespace" 'set-option -g default-command "reattach-to-user-namespace -l zsh"'
 
-# Local config
-if-shell "[ -f ~/.tmux.conf.user ]" 'source ~/.tmux.conf.user'
-
 # List of plugins
 set -g @plugin 'tmux-plugins/tpm'
 set -g @plugin 'tmux-plugins/tmux-resurrect'
@@ -214,6 +211,9 @@ set -g @plugin 'tmux-plugins/tmux-sensible'
 set -g @resurrect-save 'Z'
 set -g @resurrect-restore 'R'
 set -g @resurrect-processes 'ssh'
+
+# Local config
+if-shell "[ -f ~/.tmux.conf.user ]" 'source ~/.tmux.conf.user'
 
 # Initialize TMUX plugin manager (keep this line at the very bottom of tmux.conf)
 run '~/.tmux/plugins/tpm/tpm'


### PR DESCRIPTION
# What

These are a bunch of changes that I've been working on for the tmux.conf. Improvements include:
`ctrl-a-|` and `ctrl-a-_` to open a new pane all the way to the left or all the way to the bottom.
`` ctrl-a-` `` to open a quake-tmux in newer tmux versions.
`ctrl-a-ctrl-d` to disconnect all other connections besides the current one.
`ctrl-y` add back synchronize panes with prompt, but don't prompt on unsynchronize.

Pass `SSH_AUTH_SOCK ` on to tmux.  This is now more important than the previous `SSH_*` variables.

Change cpair.conf to a more generic include for a local and a global tmux.