### PR TITLE
Adding plugin vim-crosspaste

### DIFF
--- a/vimrc
+++ b/vimrc
@@ -430,6 +430,9 @@ map <silent> <LocalLeader>ws /\s\+$<CR>
 
 map <silent> <LocalLeader>pp :set paste!<CR>
 
+" vim-crosspaste map
+map <silent> <LocalLeader>qp :call CrossQuery()<CR>
+
 " YAML
 let g:vim_yaml_helper#auto_display_path = 1
 

--- a/vimrc.bundles
+++ b/vimrc.bundles
@@ -100,6 +100,7 @@ Plug 'machakann/vim-swap'
 Plug 'wellle/targets.vim'
 Plug 'romainl/vim-qf'
 Plug 'wellle/tmux-complete.vim'
+Plug 'https://github.braintreeps.com/braintree/vim-crosspaste'
 
 if v:version >= 800 || has('nvim')
   Plug 'w0rp/ale'

--- a/vimrc.bundles
+++ b/vimrc.bundles
@@ -100,7 +100,7 @@ Plug 'machakann/vim-swap'
 Plug 'wellle/targets.vim'
 Plug 'romainl/vim-qf'
 Plug 'wellle/tmux-complete.vim'
-Plug 'https://github.braintreeps.com/braintree/vim-crosspaste'
+Plug 'samguyjones/vim-crosspaste'
 
 if v:version >= 800 || has('nvim')
   Plug 'w0rp/ale'


### PR DESCRIPTION
e.g. If you have a query like this:

SELECT ma.token
FROM merchant_accounts ma
WHERE merchant_fk = ${merchant_pk};

and you run the crosspaste function (with \qp "query paste"
shortcut), Vim will prompt for a merchant_pk. If you type "1066",
it will then paste

SELECT ma.token
FROM merchant_accounts ma
WHERE merchant_fk = 1066;

Please use the following structure when proposing changes to our shared Vim configuration and make sure to complete the checklist at the end.

# What

Added plugin to vimrc_bundles. Added shortcut to vimrc.

# Why

Added easy paste to make it easy to run saved queries in vim.

# Checklist

- [ ] Send RFC email to Braintree developers _if change may be impactful_. Please include a link to this PR so that discussion about the pros and cons of the change remains linked to the proposed changes. **Recent examples include**: addition of linter and completer, no longer removing end-of-line whitespace on save, changing to fzf for file lookup.
