### PR TITLE
Fixed method call in map. Added mapping to README.

### DIFF
--- a/README.md
+++ b/README.md
@@ -101,3 +101,10 @@ Searching
 ```
 \nh - :nohlsearch - stop highlighting the last search
 ```
+
+CrossPaste
+
+```
+\qp - Send current block of text (from blank line before to semicolon after)
+      prompting for text substitutions
+```

--- a/vimrc
+++ b/vimrc
@@ -431,7 +431,7 @@ map <silent> <LocalLeader>ws /\s\+$<CR>
 map <silent> <LocalLeader>pp :set paste!<CR>
 
 " vim-crosspaste map
-map <silent> <LocalLeader>qp :call CrossQuery()<CR>
+map <silent> <LocalLeader>qp :call CrossPaste()<CR>
 
 " YAML
 let g:vim_yaml_helper#auto_display_path = 1


### PR DESCRIPTION
Please use the following structure when proposing changes to our shared Vim configuration and make sure to complete the checklist at the end.

# What

Fixed a mistake in a method name (as I made the plugin, I changed the method name from CrossQuery to CrossPaste, and the vimrc I pushed had
the old method name). I also added a line in the README to explain the mapping.

_Example: Specify full path when running focused specs._

# Why

It was a mistake. It didn't touch any existing fuctionality, but it didn't allow the new feature, so I'm fixing it.

_Example: When only a relative path is specified, focused specs don't run if the shell's current working directory differs from the project root._

# Checklist

- [ ] Send RFC email to Braintree developers _if change may be impactful_. Please include a link to this PR so that discussion about the pros and cons of the change remains linked to the proposed changes. **Recent examples include**: addition of linter and completer, no longer removing end-of-line whitespace on save, changing to fzf for file lookup.
