### PR TITLE
Add support for running `rustfmt` on each save

### DIFF
--- a/rust_mappings.vim
+++ b/rust_mappings.vim
@@ -1,0 +1,1 @@
+let g:rustfmt_autosave = 1

--- a/vimrc
+++ b/vimrc
@@ -93,6 +93,7 @@ autocmd FileType cs runtime dotnet_mappings.vim
 autocmd FileType javascript runtime javascript_mappings.vim
 autocmd FileType python runtime python_mappings.vim
 autocmd FileType java runtime java_mappings.vim
+autocmd FileType rust runtime rust_mappings.vim
 
 " wstrip plugin
 " don't highlight trailing whitespace


### PR DESCRIPTION
# What

Add a one-line `rust_mappings.vim` file allowing `rustfmt` to be automatically run when a buffer is saved, then include that runtime in `vimrc`.

Note that this only leveraging existing functionality in [the already-implemented `rust-lang/rust.vim` plugin](https://github.com/braintreeps/vim_dotfiles/blob/270c1c0aa4878131438592cd27ae009495c36b3c/vimrc.bundles#L66). See ["Formatting with rustfmt" docs here](https://github.com/rust-lang/rust.vim#formatting-with-rustfmt).

# Why

This will allow for a more consistent style used throughout Rust projects by running the formatter on each save.

@aklitzke - any issues with having `rustfmt` run automatically on save?