### PR TITLE
Added shortcuts for vim-crosspaste commands to paste a block or

### DIFF
--- a/vimrc
+++ b/vimrc
@@ -432,6 +432,8 @@ map <silent> <LocalLeader>pp :set paste!<CR>
 
 " vim-crosspaste map
 map <silent> <LocalLeader>qp :call CrossPaste()<CR>
+map <silent> <LocalLeader>qb :call CrossPasteBlock()<CR>
+map <silent> <LocalLeader>qq :call CrossPasteQuick()<CR>
 
 " YAML
 let g:vim_yaml_helper#auto_display_path = 1


### PR DESCRIPTION
# What

This adds two new shortcuts to the setup.  Both of them are for my vim-crosspaste plugin. One of them is

**\qb** _query block_ this takes the selected text and pastes it across TMUX panes, doing pattern substitutions the way crosspaste does. This is different from standard crosspaste that picks the text around the cursor, going back to a blank space and forward to a semicolon.

**\qq** _quick query_ this does the same thing as a standard query, but it assumes last entered information rather than prompting. e.g. If you crosspaste text with ${foo} and you've already entered "bar" as a _foo_ in a previous paste, \qq would automatically replace ${foo} instead of prompting with a default of "bar".

_Example: Specify full path when running focused specs._

# Why

\qb is more similar to how some people work, and some users of crosspaste have asked for it.

\qq can speed up work, and people often work with a bunch of very similar queries.

_Example: When only a relative path is specified, focused specs don't run if the shell's current working directory differs from the project root._