### PR TITLE
Pin vim-go to latest release

### DIFF
--- a/vimrc.bundles
+++ b/vimrc.bundles
@@ -26,7 +26,7 @@ Plug 'derekwyatt/vim-scala'
 Plug 'ekalinin/Dockerfile.vim'
 Plug 'elixir-lang/vim-elixir'
 Plug 'elubow/cql-vim'
-Plug 'fatih/vim-go', { 'do': ':GoInstallBinaries' }
+Plug 'fatih/vim-go', { 'commit': '8c4db1c61432511a3aa55971dabb2171cbcba7b1', 'do': ':GoInstallBinaries' }
 Plug 'Glench/Vim-Jinja2-Syntax'
 Plug 'godlygeek/tabular'
 Plug 'tpope/vim-markdown'


### PR DESCRIPTION
# What

See title.

# Why

This avoids warnings every time vim starts on older versions of vim and future breaking changes.

# Checklist

- [ ] Send RFC email to Braintree developers _if change may be impactful_. Please include a link to this PR so that discussion about the pros and cons of the change remains linked to the proposed changes. **Recent examples include**: addition of linter and completer, no longer removing end-of-line whitespace on save, changing to fzf for file lookup.
