### PR TITLE
Increase default fzf search window size

### DIFF
--- a/vimrc
+++ b/vimrc
@@ -219,6 +219,8 @@ let g:fzf_action = {
   \ 'ctrl-x': 'split',
   \ 'ctrl-s': 'split',
   \ 'ctrl-v': 'vsplit' }
+let g:fzf_layout = { 'window': { 'width': 1.0, 'height': 1.0 } } " Increase default size of search window, 1.0 = 100%, 0.1 = 10%
+let g:fzf_preview_window = ['down:50%', 'ctrl-_'] " 1st element is preview position size, 2nd element is shortcut to toggle preview
 
 let g:go_fmt_command = "goimports"
 let g:go_highlight_trailing_whitespace_error = 0


### PR DESCRIPTION
# What

Increase default fzf search window size to 100% height and width

Before: 
<img width="1434" alt="Screenshot 2023-09-08 at 9 45 59 AM" src="https://github.com/braintreeps/vim_dotfiles/assets/3414795/6c7864a1-dc83-449a-b9d2-7ff7fb15f61b">

After: 
<img width="1433" alt="Screenshot 2023-09-08 at 9 46 23 AM" src="https://github.com/braintreeps/vim_dotfiles/assets/3414795/c0ad1998-4534-47d5-b836-4a43592b9b61">

# Why

When working in tmux half-panes (or any smaller screen sizes) many times long file names are cut off. Because you cannot see much of the file name sometimes, this causes issues trying to select the right file if there are other similar file matches. 

Having a window/popup above the current file doesnt actually help anything, the search can just be fullscreen where the developers focus is at the time.

# Checklist

- [ ] Send RFC email to Braintree developers _if change may be impactful_. Please include a link to this PR so that discussion about the pros and cons of the change remains linked to the proposed changes. **Recent examples include**: addition of linter and completer, no longer removing end-of-line whitespace on save, changing to fzf for file lookup.
