### PR TITLE
Dont clear and echo before running test commands with vim-test

### DIFF
--- a/vimrc
+++ b/vimrc
@@ -230,6 +230,8 @@ let nose_test = system('grep -q "nose" requirements.txt')
 if v:shell_error == 0
   let test#python#runner = 'nose'
 endif
+let g:test#preserve_screen = 1 " dont clear the screen before running
+let g:test#echo_command = 0 " dont echo the command before running
 
 if filereadable(expand('WORKSPACE'))
   let test#custom_runners['java'] = ['bazeltest']


### PR DESCRIPTION
# What

Dont clear and echo before running test commands with vim-test such as `\rf`

Before:
`\rf`
`clear; echo "bundle exec rspec spec/foo/bar_spec.rb:152"; bundle exec rspec spec/foo/bar_spec:152`

After:
`\rf`
`bundle exec rspec spec/foo/bar_spec:152`

# Why

- Clearing the screen is not very helpful, many times I want to see the failures that had occured in runs prior and other details.
- The echo statement is actually confusing because sometimes you may start out with an \rf which would output
   * echo "bundle exec rspec spec/foo/bar_spec.rb:152"; bundle exec rspec spec/foo/bar_spec.rb:152"
   * Many times I want to just re-run the spec file with a different line number, you may just manually re-run the last command and change the last line `152` to something else and then your pair will be like "huh which spec are you running?" this is because of the clear and echo statement which still claims to be line `152`

# Checklist

- [ ] Send RFC email to Braintree developers _if change may be impactful_. Please include a link to this PR so that discussion about the pros and cons of the change remains linked to the proposed changes. **Recent examples include**: addition of linter and completer, no longer removing end-of-line whitespace on save, changing to fzf for file lookup.
