### PR TITLE
Default to case-insensitive fzf

### DIFF
--- a/vimrc
+++ b/vimrc
@@ -212,7 +212,7 @@ let g:puppet_align_hashes = 0
 let $FZF_DEFAULT_COMMAND = 'find . -name "*" -type f 2>/dev/null
                             \ | grep -v -E "tmp\/|.gitmodules|.git\/|deps\/|_build\/|node_modules\/|vendor\/"
                             \ | sed "s|^\./||"'
-let $FZF_DEFAULT_OPTS = '--reverse'
+let $FZF_DEFAULT_OPTS = '--reverse -i'
 let g:fzf_tags_command = 'ctags -R --exclude=".git\|.svn\|log\|tmp\|db\|pkg" --extra=+f --langmap=Lisp:+.clj'
 let g:fzf_action = {
   \ 'ctrl-t': 'tab split',


### PR DESCRIPTION
# What/Why

When searching for files in Vim I don't remember needing to respect case, and, at least in our Ruby projects, the files are default lower case anyway. Changing from the default "smart case" (which uses case insensitive matching when the input is all lower case and case sensitive matching when at least one uppercase letter is present) to to case insensitive matching always means that searching for a Ruby class name like MyClass will match my_class.rb, which seems like a usability win when copy/pasting from code.

# Checklist

- [x] Send RFC email to Braintree developers _if change may be impactful_. Please include a link to this PR so that discussion about the pros and cons of the change remains linked to the proposed changes. **Recent examples include**: addition of linter and completer, no longer removing end-of-line whitespace on save, changing to fzf for file lookup.

Note: discussed internally with poll on behavior change.
