### PR TITLE
Un-pegging vim-ruby to a very old commit

### DIFF
--- a/vimrc.bundles
+++ b/vimrc.bundles
@@ -86,7 +86,7 @@ Plug 'tpope/vim-unimpaired'
 Plug 'tpope/vim-vinegar'
 Plug 'tpope/vim-abolish'
 Plug 'uarun/vim-protobuf'
-Plug 'vim-ruby/vim-ruby', { 'commit': '84565856e6965144e1c34105e03a7a7e87401acb' }
+Plug 'vim-ruby/vim-ruby'
 Plug 'vim-scripts/Align'
 Plug 'vim-scripts/VimClojure'
 Plug 'vim-scripts/groovyindent-unix'


### PR DESCRIPTION
# What

`vim-ruby` was pegged to a commit from 2018, it's been updated a bunch since then and I believe we can safely adopt the newer versions.  This commit un-pegs the plugin from the specified commit.

# Why

Newer versions of `vim-ruby` have improvements but also allows to match certain rubocop rules better, eg: https://github.com/vim-ruby/vim-ruby/blob/master/doc/ft-ruby-indent.txt#L112 is a change that's not included in the version we were using but fixes some indentation issues.

Screen recording that shows basic ruby working after updating the plugin:

![vim-ruby](https://github.com/braintreeps/vim_dotfiles/assets/29512/adc37ad6-39d0-4d8b-921f-76d00b8fa930)


# Checklist

- [ ] Send RFC email to Braintree developers _if change may be impactful_. Please include a link to this PR so that discussion about the pros and cons of the change remains linked to the proposed changes. **Recent examples include**: addition of linter and completer, no longer removing end-of-line whitespace on save, changing to fzf for file lookup.
