### PR TITLE
Add editorconfig support to more easily manage respecting projects coding style

### DIFF
--- a/vimrc.bundles
+++ b/vimrc.bundles
@@ -101,6 +101,7 @@ Plug 'wellle/targets.vim'
 Plug 'romainl/vim-qf'
 Plug 'wellle/tmux-complete.vim'
 Plug 'samguyjones/vim-crosspaste'
+Plug 'editorconfig/editorconfig-vim'
 
 if v:version >= 800 || has('nvim')
   Plug 'w0rp/ale'


### PR DESCRIPTION
# What

Add editorconfig plugin.

# Why

I'm contributing to an open-source project that is using .editorconfig to help folks respect their use of tabs rather than spaces. I think that's a great idea and there are places where it might be useful for us to adopt it as well. 

https://editorconfig.org/