### PR TITLE
Revert "markdown: auto format markdown files with pandoc"

### DIFF
--- a/ftplugin/markdown.vim
+++ b/ftplugin/markdown.vim
@@ -14,5 +14,3 @@ let g:markdown_fenced_languages = [
 \  'ruby',
 \  'rust',
 \]
-" auto format markdown files with pandoc
-let g:ale_fixers['markdown'] = ['pandoc']


### PR DESCRIPTION
Reverts braintreeps/vim_dotfiles#199

After asking around, it seems a lot of people share at least some of my sentiments on this:

* This fixer doesn't "kick in" consistently; markdown files in vim will seemingly randomly suddenly start getting formatted by this. Having to know how to invoke the fixer manually is annoying extra cognitive burden of which the A in ALE is supposed to relieve us, yet it's not holding up that end of the bargain.
* Once the fixer _does_ "kick in", it can't be fought against, to the point where changing a single line in a readme suddenly becomes a 300+ line change for no good reason. This leads to people making separate PRs just to apply the formatting, then a PR on top of that to actually make the desired change.
* The formatting is aesthetically displeasing, though opinions do differ on which parts are displeasing. For me, it's the way it over-indents lists despite a 72-character column limit and adds unnecessary line breaks as if it's not GFM-aware. For others, it's the column limit itself. And for others still, it's the way it forces incrementing numbers on ordered lists. And I'm sure there's more valid gripes that I haven't even heard of.

Pandoc is a tool that's more suitable for converting from a nice, easy-to-write format (like markdown) into a format that can be styled and printed (html, latex, etc.) It's not something that was designed to create easily-editable documents. While it can be configured to some degree, ultimately, it's opinionated about what its output format will look like. Even though it lets you output stuff to formats like markdown, that doesn't mean you should then take the output result and run with it. It doesn't even reduce the burden of having to rejoin line breaks as you edit them, so its auto-formatting ends up getting in the way of its own goals... because it's a tool whose output is supposed to be more or less read-only. At least, that's my opinion, which seems to be shared by enough others.

I think if someone wants to use an alternate solution, they should address both the problem of the ALE fixer not kicking in consistently, and also they should use something besides pandoc. For now, though, everyone who responded to my inquiries would rather have this fixer disabled and replaced with nothing, so, here's exactly that. From what I can tell, just reverting the original PR is all we need to do.