### PR TITLE
*.rbi files are generated by the sorbet gem and can be ignored

### DIFF
--- a/vimrc
+++ b/vimrc
@@ -367,7 +367,7 @@ function! SmartFuzzy()
   if len(root) == 0 || v:shell_error
     Files
   else
-    GFiles -co --exclude-standard -- . ':!:vendor/*'
+    GFiles -co --exclude-standard -- . ':!:vendor/*' ':!:*.rbi'
   endif
 endfunction
 


### PR DESCRIPTION
# What

Ignore .rbi files while fuzzy-finding, yet do not .gitignore them.

# Why

.rbi files are autogenerated by Sorbet and disrupt fuzzy-finding.
