### PR TITLE
Add unobtrusive tips of the day plugin

### DIFF
--- a/vimrc.bundles
+++ b/vimrc.bundles
@@ -102,6 +102,7 @@ Plug 'romainl/vim-qf'
 Plug 'wellle/tmux-complete.vim'
 Plug 'samguyjones/vim-crosspaste'
 Plug 'nathanaelkane/vim-indent-guides'
+Plug 'git@github.com:braintreeps/totd-vim.git', { 'branch': 'main' }
 
 if v:version >= 800 || has('nvim')
   Plug 'w0rp/ale'


### PR DESCRIPTION
# What

Without further configuration *this is a no-op*.

This adds a simple, currently private (closed source) plugin that
takes a random line of text from a `~/.vimtips` file. It then displays
that line in the "messages" bar at the bottom of the screen. That
message is ephemeral and un-obtrusive. 

That file will need to be managed internally if we populate it with tips
that give private details about our environment. For now it is private.
And it does not exist (except in my personal dotfiles).

Future decisions can enable us to do any of the following:

1. Add a default 'vimptips' that only documents our open source dotfiles
2. Add a private 'vimtips' file that has internal information if such
   information exists and is useful in using `vim` (unsure)
3. Support per-language `vimtips` via ftplugin
4. Support per-project `.vimtips` for helpful usages specific to a repo

Also, in the future, I would like us to be able to additionally detect
whether `vim` or `neovim` is loading the plugin and display usages
specific to each.

I will follow this PR with a `.vimtips` file that can be populated on
our development machines and will seek feedback on the tip to be added.

# Why

After working here for 13+ years I still find new, useful, commands and
usages of our dotfiles. I want to my fellow Braintree devs to showcase
useful functionality and make efficient usage of our `vim`/`nvim` setups

# Checklist

- [x] This PR does nothing without a separately managed "tips" file. I
  will seek feedback from Braintree developers and technical guidance
  before populating the tips file
