### PR TITLE
Move window navigation bindings

### DIFF
--- a/vimrc
+++ b/vimrc
@@ -597,6 +597,13 @@ endfunction
 
 call s:EnableShfmt()
 
+" Navigate windows without <C-w>
+
+nmap <silent> <C-h> <C-w><C-h>
+nmap <silent> <C-j> <C-w><C-j>
+nmap <silent> <C-k> <C-w><C-k>
+nmap <silent> <C-l> <C-w><C-l>
+
 "-------- Local Overrides
 ""If you have options you'd like to override locally for
 "some reason (don't want to store something in a
@@ -626,10 +633,3 @@ endif
 if filereadable(expand('~/.vimrc_local'))
   source ~/.vimrc_local
 end
-
-" Navigate windows without <C-w>
-
-nmap <silent> <C-h> <C-w><C-h>
-nmap <silent> <C-j> <C-w><C-j>
-nmap <silent> <C-k> <C-w><C-k>
-nmap <silent> <C-l> <C-w><C-l>


### PR DESCRIPTION
Moving these bindings above the system and local overrides allows them to be overridden by these overrides. Otherwise there is no sensible way to deviate from these key bindings.

Original commit: 4b3bba2

Please use the following structure when proposing changes to our shared Vim configuration and make sure to complete the checklist at the end.

# What

Move window navigation bindings above the system and local overrides.

# Why

Moving these bindings above the system and local overrides allows them to be overridden by these overrides. Otherwise there is no sensible way to deviate from these key bindings.

Original commit adding bindings: 4b3bba2
