### PR TITLE
Fix airblade/vim-gitgutter Plugin updates

### DIFF
--- a/vimrc.bundles
+++ b/vimrc.bundles
@@ -12,7 +12,7 @@ Plug 'akhaku/vim-java-unused-imports'
 Plug 'aklt/plantuml-syntax'
 Plug 'arthurxavierx/vim-caser'
 " Show git diff via Vim sign column.
-Plug 'airblade/vim-gitgutter'
+Plug 'airblade/vim-gitgutter', {'branch': 'main'}
 Plug 'google/vim-maktaba'
 Plug 'google/vim-glaive'
 Plug 'google/vim-codefmt'


### PR DESCRIPTION


# What

Fix airblade/vim-gitgutter Plugin updates

# Why

Without specifying the "main" branch, vim-plug tries to update from the non-existent "master" branch.

```
x vim-gitgutter:
    fatal: invalid reference: master
```

Similar to:

```
Plug 'cespare/vim-toml', {'branch': 'main'}
```

Plugin github link: https://github.com/airblade/vim-gitgutter
