### PR TITLE
Add copilot.vim, disabled by default with a toggle

### DIFF
--- a/vimrc
+++ b/vimrc
@@ -335,6 +335,30 @@ if !has('nvim-0.5')
   call s:setup_vim_lsp()
 endif
 
+"
+" ========= AI ========
+"
+" Mappings
+" ---------------------
+"
+" [c]opilot [a]uto-completions
+map <silent> <leader>ca :call ToggleCopilotCompletions()<CR>
+
+" Functions
+" ---------------------
+
+" Disable copilot.vim completions by default
+let g:copilot_enabled = 0
+func! ToggleCopilotCompletions()
+  if g:copilot_enabled
+    let g:copilot_enabled = 0
+    echo "Copilot completions disabled"
+  else
+    let g:copilot_enabled = 1
+    echo "Copilot completions enabled"
+  endif
+endfunc
+
 " ========= Shortcuts ========
 
 " ALE

--- a/vimrc.bundles
+++ b/vimrc.bundles
@@ -103,6 +103,8 @@ Plug 'wellle/tmux-complete.vim'
 Plug 'samguyjones/vim-crosspaste'
 Plug 'nathanaelkane/vim-indent-guides'
 
+Plug 'github/copilot.vim'
+
 if v:version >= 800 || has('nvim')
   Plug 'w0rp/ale'
 endif


### PR DESCRIPTION
Add the plugin, disable it, and add a toggle.

# What

This adds the official vim copilot integration, `copilot.vim`.

This plugin is basically just autocompletions for now. They should not be enabled by default.

To get started, pull and `:Copilot setup`

# Why

We want to provide options for using GenAI at Braintree without disrupting existing workflows.
