### PR TITLE
Add finders for {i,v}maps

### DIFF
--- a/vimrc
+++ b/vimrc
@@ -400,7 +400,12 @@ map <silent> <leader>ff :SmartFuzzy<CR>
 map <silent> <leader>fg :GFiles<CR>
 map <silent> <leader>fb :Buffers<CR>
 map <silent> <leader>ft :Tags<CR>
+" [f]ind [m]aps (normal mode)
 map <silent> <leader>fm :Maps<CR>
+" [f]ind [m]aps [v]isual mode
+map <silent> <leader>fmv fzf#vim#maps("v")<CR>
+" [f]ind [m]aps [i]nsert mode
+map <silent> <leader>fmi fzf#vim#maps("i")<CR>
 
 map <silent> <C-p> :Files<CR>
 

--- a/vimrc.bundles
+++ b/vimrc.bundles
@@ -103,7 +103,7 @@ Plug 'wellle/tmux-complete.vim'
 Plug 'samguyjones/vim-crosspaste'
 Plug 'nathanaelkane/vim-indent-guides'
 
-Plug 'github/copilot.vim'
+Plug 'github/copilot.vim', { 'branch': 'release' }
 
 if v:version >= 800 || has('nvim')
   Plug 'w0rp/ale'


### PR DESCRIPTION
# What

`\fm` already exists and unfortunately `:Maps` in fzf-vim only shows
normal mode maps. The underlying function shows one kind of map at a
time.

This adds `\fm{v,i}`.

# Why

Debugging missing maps in our neovim dotfiles.
